### PR TITLE
Support --force flag for 'new' PenText repositories

### DIFF
--- a/pull_upstream_changes.sh
+++ b/pull_upstream_changes.sh
@@ -2,7 +2,7 @@
 
 # pull_upstream_changes - Updates repo and applies upstream changes
 #
-# Copyright (C) 2016 Peter Mosmans [Radically Open Security]
+# Copyright (C) 2016-2017 Peter Mosmans [Radically Open Security]
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -19,15 +19,21 @@ SOURCEROOT="xml"
 
 
 ## Don't change anything below this line
-VERSION=0.6
+VERSION=0.7
 
 source=$(dirname $(readlink -f $0))
+
+if [ "$1" == "--force" ]; then
+    force=true
+    shift
+fi
+
 target=$1
 
 if [ -z "$target" ]; then
     target=$(readlink -f .)
     if [ "${target}" == "${source}" ]; then
-        echo "Usage: pull_upstream_changes [TARGET]"
+        echo "Usage: pull_upstream_changes [--force] [TARGET]"
         echo "       or run from within target directory"
         exit
     fi
@@ -35,8 +41,12 @@ fi
 
 # Check if the target actually contains the repository
 if [ ! -z ${FINGERPRINT} ] && [ ! -d $target/dtd ]; then
-   echo "[-] ${target} does not contain the correct repository"
-   exit
+    echo "[-] ${target} does not contain the correct repository"
+    if [ -z $force ]; then
+        exit
+    else
+        echo "[*] --force option: continuing anyway..."
+    fi
 fi
 
 # Update repository
@@ -47,7 +57,10 @@ pushd "$source" >/dev/null && git pull && popd >/dev/null
 echo "[*] Applying changes (if any)..."
 for sourcefile in ${SOURCEFILES}; do
     if [ -d "${source}/${SOURCEROOT}/${sourcefile}" ]; then
-       cp -prv ${source}/${SOURCEROOT}/${sourcefile} $target/
+        if [ ! -z $force ]; then
+            mkdir -p ${target}/${sourcefile} 1>/dev/null
+        fi
+       cp -prv ${source}/${SOURCEROOT}/${sourcefile}/* $target/${sourcefile}/
     else
         cp -pv ${source}/${SOURCEROOT}/${sourcefile} $target/${sourcefile}
     fi


### PR DESCRIPTION
The --force flag allows repositories not containing the PenText repository to
'update' to the latest version of PenText.