### PR TITLE
Add support for status attribute when using finding_count

### DIFF
--- a/xml/xslt/placeholders.xslt
+++ b/xml/xslt/placeholders.xslt
@@ -412,9 +412,26 @@
 
     <xsl:template match="finding_count">
         <xsl:param name="threatLevel" select="@threatLevel"/>
+        <xsl:variable name="statusSequence" as="item()*">
+            <xsl:for-each select="@status">
+                <xsl:for-each select="tokenize(., ' ')">
+                    <xsl:value-of select="."/>
+                </xsl:for-each>
+            </xsl:for-each>
+        </xsl:variable>
         <xsl:choose>
             <xsl:when test="@threatLevel">
-                <xsl:value-of select="count(//finding[@threatLevel = $threatLevel])"/>
+                <xsl:choose>
+                    <xsl:when test="$statusSequence">
+                        <xsl:value-of select="count(//finding[@threatLevel =
+                                              $threatLevel][@status =
+                                              $statusSequence])"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:value-of select="count(//finding[@threatLevel =
+                                              $threatLevel])"/>
+                    </xsl:otherwise>
+                </xsl:choose>
             </xsl:when>
             <xsl:otherwise>
                 <xsl:value-of select="count(//finding)"/>


### PR DESCRIPTION
This allows users to count findings based on threatLevel, as well as based on one or more discrete status values.

Example in XML:
   <finding_count threatLevel="High" status="new unresolved"/>

This will count the number of findings having attribute threatLevel="High", AND a status of either "new" OR "unresolved".

This change is backwards-compatible: Using finding_count without the status attribute will show the same results as before.