### PR TITLE
WIP: Refactoring of the default finding template

### DIFF
--- a/chatops/python/gitlab-to-pentext.py
+++ b/chatops/python/gitlab-to-pentext.py
@@ -91,9 +91,9 @@ class Finding(BaseItem):
         self.threat_level = 'Moderate'
         self.finding_type = 'TODO'
         self.status = 'new'
-        self.description = '<p>TODO</p>'
-        self.technicaldescription = '<p>TODO</p>'
-        self.impact = '<p>TODO</p>'
+        self.description = 'TODO'
+        self.technicaldescription = 'TODO'
+        self.impact = 'TODO'
         self.recommendation = '<ul><li>TODO</li></ul>'
 
     def __str__(self):


### PR DESCRIPTION
Hey, I am working on refactoring the output of the default gitlab issue->xml structure.
I want to implement proper indentation and formatting including line-breaks at 80 characters.
This perhaps includes creating default finding templates for issues in Gitlab/Github with compatible
markdown structure for xml conversion.

Currently there is a html parsing of the markdown, which creates issues like #58.
