### PR TITLE
Allow finding_count to use (multiple) status attribute values

### DIFF
--- a/xml/dtd/pentestreport.xsd
+++ b/xml/dtd/pentestreport.xsd
@@ -415,6 +415,7 @@
       <xs:element name="finding_count">
         <xs:complexType>
           <xs:attribute ref="threatLevel" use="optional"/>
+          <xs:attribute ref="status" use="optional"/>
         </xs:complexType>
       </xs:element>
       <xs:element name="todo"/>

--- a/xml/xslt/placeholders.xslt
+++ b/xml/xslt/placeholders.xslt
@@ -466,7 +466,14 @@
                 </xsl:choose>
             </xsl:when>
             <xsl:otherwise>
-                <xsl:value-of select="count(//finding)"/>
+              <xsl:choose>
+                <xsl:when test="$statusSequence">
+                  <xsl:value-of select="count(//finding[@status = $statusSequence])"/>
+                </xsl:when>
+                <xsl:otherwise>
+                  <xsl:value-of select="count(//finding)"/>
+                </xsl:otherwise>
+              </xsl:choose>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>


### PR DESCRIPTION
This PR allows the use of multiple status attributes, when using the `finding_count` element without any other attributes.

Example:
```
<finding_count status="unresolved resolved not_retested" />
```