### PR TITLE
Update Tools manual.md

### DIFF
--- a/xml/doc/Tools manual.md
+++ b/xml/doc/Tools manual.md
@@ -32,7 +32,7 @@ Download Apache FOP 2.1 at https://xmlgraphics.apache.org/fop/download.html and 
 
 ### Fonts
 
-Download the Liberation Sans font from http://www.fontsquirrel.com/fonts/liberation-sans and install.
+Download the Liberation Sans font from https://releases.pagure.org/liberation-fonts/liberation-fonts-ttf-1.07.4.tar.gz and install.
 
 Download the Liberation Mono font from http://www.fontsquirrel.com/fonts/Liberation-Mono and install.
 


### PR DESCRIPTION
The fonts pointed to by the link no longer contain the "narrow" fonts due to a licensing issue. The pentext system needs these narrow fonts
to function correctly. The proposed change includes a link to an older version of this font, that does inlude the narrow fonts.
For more info, see here: https://github.com/liberationfonts/liberation-sans-narrow