### PR TITLE
support business weeks in service breakdown

### DIFF
--- a/xml/xslt/functions_params_vars.xslt
+++ b/xml/xslt/functions_params_vars.xslt
@@ -139,6 +139,9 @@
                                         <xsl:when test="effort/@in = 'days'">
                                             <xsl:value-of select="effort/min * 8"/>
                                         </xsl:when>
+                                        <xsl:when test="effort/@in = 'weeks'">
+                                            <xsl:value-of select="effort/min * 8 * 5"/>
+                                        </xsl:when>
                                     </xsl:choose>
                                 </min>
                                 <max>
@@ -148,6 +151,9 @@
                                         </xsl:when>
                                         <xsl:when test="effort/@in = 'days'">
                                             <xsl:value-of select="effort/max * 8"/>
+                                        </xsl:when>
+                                        <xsl:when test="effort/@in = 'weeks'">
+                                            <xsl:value-of select="effort/max * 8 * 5"/>
                                         </xsl:when>
                                     </xsl:choose>
                                 </max>
@@ -162,6 +168,9 @@
                                         <xsl:when test="effort/@in = 'days'">
                                             <xsl:value-of select="effort * 8"/>
                                         </xsl:when>
+                                        <xsl:when test="effort/@in = 'weeks'">
+                                            <xsl:value-of select="effort * 8 * 5"/>
+                                        </xsl:when>
                                     </xsl:choose>
                                 </min>
                                 <max>
@@ -171,6 +180,9 @@
                                         </xsl:when>
                                         <xsl:when test="effort/@in = 'days'">
                                             <xsl:value-of select="effort * 8"/>
+                                        </xsl:when>
+                                        <xsl:when test="effort/@in = 'weeks'">
+                                            <xsl:value-of select="effort * 8 * 5"/>
                                         </xsl:when>
                                     </xsl:choose>
                                 </max>
@@ -261,6 +273,10 @@
             <xsl:when test="effort/@in = 'days'">
                 <!-- multiply with hourly rate * 8 -->
                 <xsl:value-of select="$for * hourly_rate * 8"/>
+            </xsl:when>
+            <xsl:when test="effort/@in = 'weeks'">
+                <!-- multiply with hourly rate * 8 * 5 -->
+                <xsl:value-of select="$for * hourly_rate * 8 * 5"/>
             </xsl:when>
         </xsl:choose>
     </xsl:template>


### PR DESCRIPTION
Pentext understands the service breakdown in hours or days, but not yet in business-weeks. To improve the visualization in the PDF file, this change adds support for business-weeks (shorthand weeks).

It is okay to call a business week just a "week" because on one hand it is the general understanding of authors and readers, but also it is broken down in hours in the final PDF version.