### PR TITLE
support markdown line-through text

### DIFF
--- a/xml/xslt/inline.xslt
+++ b/xml/xslt/inline.xslt
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-    xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="xs" version="2.0">
+<xsl:stylesheet version="2.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:fo="http://www.w3.org/1999/XSL/Format"
+    exclude-result-prefixes="xs">
 
     <xsl:template name="checkLinkValidity">
         <xsl:if test="not(starts-with(@href, '#')) and not(contains(@href, '://')) and not(contains(@href, 'mailto:'))">
@@ -15,6 +18,13 @@
         <xsl:call-template name="displayErrorText">
                     <xsl:with-param name="string">### TODO<xsl:if test="@desc or not(normalize-space() = '')">: <xsl:value-of select="@desc"/><xsl:value-of select="."/></xsl:if> ###</xsl:with-param>
                 </xsl:call-template>
+    </xsl:template>
+
+    <xsl:template match="del">
+        <fo:inline>
+            <xsl:attribute name="text-decoration">line-through</xsl:attribute>
+            <xsl:apply-templates/>
+        </fo:inline>
     </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
- Add support for markdown `~ strikethrough~` text.

When rendered to HTML strikethrough text is enclosed in a `<del>` inline element. This change converts it into a `fo:inline` element with according `text-decoration="line-through"` attribute.