### PR TITLE
fix: use quoting and correct number in CSV export

### DIFF
--- a/xml/xslt/findings2csv.xsl
+++ b/xml/xslt/findings2csv.xsl
@@ -1,36 +1,42 @@
 <?xml version="1.0"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="text" />
-	<xsl:strip-space elements="*"/>
-	<xsl:variable name="delimiter">;</xsl:variable>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="text"/>
+  <xsl:strip-space elements="*"/>
+  <xsl:variable name="delimiter">&quot;,&quot;</xsl:variable>
+  <xsl:variable name="quote" select="'&quot;'" />
+  <xsl:template match="/pentest_report">
+    <xsl:apply-templates select="//finding"/>
+  </xsl:template>
+  <!-- finding -->
+  <xsl:template match="finding">
+    <xsl:value-of select="$quote"/>
+    <xsl:value-of select="concat(/pentest_report/@findingCode,'-',string(format-number(@number,'000')))"/>
+    <xsl:value-of select="$delimiter"/>
+    <xsl:value-of select="normalize-space(title)"/>
+    <xsl:value-of select="$delimiter"/>
+    <xsl:value-of select="@type"/>
+    <xsl:value-of select="$delimiter"/>
+    <xsl:value-of select="@threatLevel"/>
+    <xsl:value-of select="$delimiter"/>
+    <xsl:value-of select="normalize-space(description)"/>
+    <xsl:value-of select="$delimiter"/>
+    <xsl:choose>
+      <xsl:when test="string-length(recommendation/ul) &gt; 0">
+        <xsl:for-each select="recommendation/ul/li">
+          <xsl:value-of select="normalize-space(.)"/>
+          <xsl:if test="position() &lt; last()">
+            <xsl:text> </xsl:text>
+          </xsl:if>
+        </xsl:for-each>
+      </xsl:when>
+      <xsl:when test="string-length(recommendation/p) &gt; 0">
+        <xsl:value-of select="normalize-space(recommendation/p)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="normalize-space(recommendation)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:text>&quot;&#xa;</xsl:text>
+  </xsl:template>
 
-	<xsl:template match="/pentest_report">
-		<xsl:apply-templates select="//finding"/>
-	</xsl:template>
-
-	<!-- finding -->
-	<xsl:template match="finding">
-		<xsl:value-of select="concat(/pentest_report/@findingCode,'-',string(format-number(position(),'000')))"/><xsl:value-of select="$delimiter"/>
-		<xsl:value-of select="@type"/><xsl:value-of select="$delimiter"/>
-		<xsl:value-of select="@threatLevel"/><xsl:value-of select="$delimiter"/>
-		<xsl:value-of select="translate(description/p,$delimiter,',')"/><xsl:value-of select="$delimiter"/>
-		<xsl:choose>
-			<xsl:when test="string-length(recommendation/ul) &gt; 0">
-				<xsl:for-each select="recommendation/ul/li">
-					<xsl:value-of select="translate(.,$delimiter,',')"/>
-					<xsl:if test="position() &lt; last()">
-						<xsl:text> </xsl:text>
-					</xsl:if>
-				</xsl:for-each>
-			</xsl:when>
-			<xsl:when test="string-length(recommendation/p) &gt; 0">
-				<xsl:value-of select="translate(recommendation/p,$delimiter,',')"/>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="translate(recommendation,$delimiter,',')"/>
-			</xsl:otherwise>
-		</xsl:choose>
-		<xsl:text>
-</xsl:text>
-	</xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
This XSLT properly exports findings to the CSV format.
Fields are enclosed using double quotes, and separated by commas.
Line breaks are removed.
The correct finding ID is being used.