### PR TITLE
Fix: don't show the content of the labels in findings

### DIFF
--- a/xslt/findings.xslt
+++ b/xslt/findings.xslt
@@ -101,11 +101,10 @@
 
             </fo:table-body>
         </fo:table>
+      </xsl:template>
 
-
-
-
-    </xsl:template>
+    <!-- ignore label content in the findings -->
+    <xsl:template match="label" />
 
     <!-- ignore summary-table-only elements in the findings -->
     <xsl:template match="description_summary | recommendation_summary"/>

--- a/xslt/findings.xslt
+++ b/xslt/findings.xslt
@@ -181,13 +181,13 @@
                 <xsl:if test="@date">
                     <xsl:text> </xsl:text>
                     <fo:inline xsl:use-attribute-sets="status-tag">
-                        <xsl:value-of select="@date"/>                            
+                        <xsl:value-of select="@date"/>
                     </fo:inline>
                 </xsl:if>
                 <xsl:if test="@version">
                     <xsl:text> </xsl:text>
                     <fo:inline xsl:use-attribute-sets="status-tag">
-                        <xsl:value-of select="@version"/>                            
+                        <xsl:value-of select="@version"/>
                     </fo:inline>
                 </xsl:if>
                 <xsl:text>:</xsl:text>


### PR DESCRIPTION
This PR fixes the issue that when labels are set in a finding, the content of the labels is shown verbatim (outside of the header).