### PR TITLE
fix: ensure that (sample) generic documents can be created again

### DIFF
--- a/xslt/generate_document.xsl
+++ b/xslt/generate_document.xsl
@@ -14,6 +14,7 @@
     <xsl:import href="table.xslt"/>
     <xsl:import href="lists.xslt"/>
     <xsl:import href="fo_inline.xslt"/>
+    <xsl:import href="att-set.xslt"/>
     <xsl:import href="graphics.xslt"/>
     <xsl:import href="generic.xslt"/>
     <xsl:import href="numbering.xslt"/>


### PR DESCRIPTION
The current version of generic document didn't compile properly - this fixes that issue.