### PR TITLE
fix: ignore template label tag

### DIFF
--- a/xslt/findings.xslt
+++ b/xslt/findings.xslt
@@ -101,6 +101,9 @@
         </fo:table>
     </xsl:template>
 
+    <!-- ignore label content in the findings -->
+    <xsl:template match="label" />
+
     <!-- ignore summary-table-only elements in the findings -->
     <xsl:template match="description_summary | recommendation_summary"/>
 


### PR DESCRIPTION
Don't render `<labels>` in a `<finding>` tag.