### PR TITLE
feat: remove hidden inline links (aria-hidden=true)

### DIFF
--- a/xslt/fo_inline.xslt
+++ b/xslt/fo_inline.xslt
@@ -40,6 +40,9 @@
                     <xsl:with-param name="execsummary_linking_to_content_not_in_report" select="true()"></xsl:with-param>
                 </xsl:call-template>
             </xsl:when>
+            <xsl:when test="(@aria-hidden='true') or (@aria-hidden)">
+                <!-- ignore hidden links -->
+            </xsl:when>
             <xsl:otherwise>
                 <fo:basic-link xsl:use-attribute-sets="link">
                     <xsl:choose>


### PR DESCRIPTION
When converting code blocks with syntax highlighting hidden links get inserted into the HTML content. These are supposed to be used as hidden anchors to scroll to a referenced line of code. In a PDF document we do not need them, as findings are the level of anchors the document provides.

Instead of inserting an empty `(page 0)` reference, with this change such links simply get ignored.