### PR TITLE
Add role classification to testing team listing

### DIFF
--- a/xslt/auto.xslt
+++ b/xslt/auto.xslt
@@ -275,6 +275,9 @@
                                     <fo:block>
                                         <xsl:apply-templates select="name"/>
                                     </fo:block>
+                                    <fo:block xsl:use-attribute-sets="italic">
+                                        (pentester)
+                                    </fo:block>
                                 </fo:table-cell>
                                 <fo:table-cell xsl:use-attribute-sets="td">
                                     <fo:block>
@@ -289,6 +292,9 @@
                             <fo:table-cell xsl:use-attribute-sets="td">
                                 <fo:block>
                                     <xsl:apply-templates select="name"/>
+                                </fo:block>
+                                <fo:block xsl:use-attribute-sets="italic">
+                                    (approver)
                                 </fo:block>
                             </fo:table-cell>
                             <fo:table-cell xsl:use-attribute-sets="td">


### PR DESCRIPTION
This PR does a small but meaningful step towards one of the sub-goals of #102 , namely to clarify the role of people mentioned in the testing team summary table.

Rendered example of how this looks on the example report:
![ros_pentext_testing_team_role_classification1](https://github.com/user-attachments/assets/169bde88-15f7-4a0c-96d9-bd8e87852ba8)
Note the new subtitle `(pentester)` and `(approver)` in the left name column.
