### PR TITLE
[fix] skip layout for hidden sections

### DIFF
--- a/xslt/pages.xslt
+++ b/xslt/pages.xslt
@@ -300,7 +300,9 @@
             </xsl:when>
             <xsl:otherwise>
                 <xsl:for-each select="/*/section | /*/appendix">
-                    <xsl:call-template name="generate_pages"/>
+                    <xsl:if test="not(./@visibility = 'hidden')">
+                        <xsl:call-template name="generate_pages"/>
+                    </xsl:if>
                 </xsl:for-each>
             </xsl:otherwise>
         </xsl:choose>


### PR DESCRIPTION
When hiding top-level sections in a document by setting visibility to `hidden`, the resulting PDF may contain empty pages because the page layout is rendered, but without any content. To avoid this, the layout is only applied for sections that are not hidden.

Example to hide finding details, but leave the summary tables and charts:

```
<section id="findings" visibility="hidden">
...
</section>
```