### PR TITLE
localize dates according to document lang in NL, DE and EN (default)

### DIFF
--- a/xslt/dates.xsl
+++ b/xslt/dates.xsl
@@ -1,3 +1,7 @@
+<!--
+Hardcoded localization for dates in NL, DE and EN (default)
+to support internationalized dates according to document $lang
+-->
 <xsl:stylesheet
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:xs="http://www.w3.org/2001/XMLSchema"

--- a/xslt/dates.xsl
+++ b/xslt/dates.xsl
@@ -88,7 +88,12 @@ to support internationalized dates according to document $lang
         <xsl:sequence select="concat($day, ' ', $mname, ' ', $yr)"/>
       </xsl:when>
 
-      <!-- English (default): "Month D, YYYY" -->
+      <!-- English (GB): "D Month YYYY" -->
+      <xsl:when test="$lang = 'en-GB'">
+        <xsl:sequence select="concat($day, ' ', $mname, ' ', $yr)"/>
+      </xsl:when>
+
+      <!-- English (US, default): "Month D, YYYY" -->
       <xsl:otherwise>
         <xsl:sequence select="concat($mname, ' ', $day, ', ', $yr)"/>
       </xsl:otherwise>

--- a/xslt/dates.xsl
+++ b/xslt/dates.xsl
@@ -1,0 +1,132 @@
+<xsl:stylesheet
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:fo="http://www.w3.org/1999/XSL/Format"
+    xmlns:dt-local="http://www.radical.sexy/schema/dt-local"
+    version="2.0"
+    exclude-result-prefixes="dt-local">
+
+  <xsl:variable name="month-de">
+    <m num="1"  name="Januar"/>
+    <m num="2"  name="Februar"/>
+    <m num="3"  name="März"/>
+    <m num="4"  name="April"/>
+    <m num="5"  name="Mai"/>
+    <m num="6"  name="Juni"/>
+    <m num="7"  name="Juli"/>
+    <m num="8"  name="August"/>
+    <m num="9"  name="September"/>
+    <m num="10" name="Oktober"/>
+    <m num="11" name="November"/>
+    <m num="12" name="Dezember"/>
+  </xsl:variable>
+
+  <xsl:variable name="month-nl">
+    <m num="1"  name="januari"/>
+    <m num="2"  name="februari"/>
+    <m num="3"  name="maart"/>
+    <m num="4"  name="april"/>
+    <m num="5"  name="mei"/>
+    <m num="6"  name="juni"/>
+    <m num="7"  name="juli"/>
+    <m num="8"  name="augustus"/>
+    <m num="9"  name="september"/>
+    <m num="10" name="oktober"/>
+    <m num="11" name="november"/>
+    <m num="12" name="december"/>
+  </xsl:variable>
+
+  <xsl:variable name="month-en">
+    <m num="1"  name="January"/>
+    <m num="2"  name="February"/>
+    <m num="3"  name="March"/>
+    <m num="4"  name="April"/>
+    <m num="5"  name="May"/>
+    <m num="6"  name="June"/>
+    <m num="7"  name="July"/>
+    <m num="8"  name="August"/>
+    <m num="9"  name="September"/>
+    <m num="10" name="October"/>
+    <m num="11" name="November"/>
+    <m num="12" name="December"/>
+  </xsl:variable>
+
+  <xsl:function name="dt-local:format-date-local" as="xs:string">
+    <xsl:param name="d"    as="xs:date"/>
+    <xsl:param name="lang" as="xs:string"/>
+
+    <xsl:variable name="day" select="day-from-date($d)"/>
+    <xsl:variable name="mon" select="month-from-date($d)"/>
+    <xsl:variable name="yr"  select="year-from-date($d)"/>
+
+    <xsl:variable name="mname">
+      <xsl:choose>
+        <xsl:when test="$lang = 'de'">
+          <xsl:value-of select="$month-de/m[@num = $mon]/@name"/>
+        </xsl:when>
+        <xsl:when test="$lang = 'nl'">
+          <xsl:value-of select="$month-nl/m[@num = $mon]/@name"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="$month-en/m[@num = $mon]/@name"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
+
+    <xsl:choose>
+      <!-- German: "D. Monat YYYY" -->
+      <xsl:when test="$lang = 'de'">
+        <xsl:sequence select="concat($day, '. ', $mname, ' ', $yr)"/>
+      </xsl:when>
+
+      <!-- Dutch: "D maand YYYY" -->
+      <xsl:when test="$lang = 'nl'">
+        <xsl:sequence select="concat($day, ' ', $mname, ' ', $yr)"/>
+      </xsl:when>
+
+      <!-- English (default): "Month D, YYYY" -->
+      <xsl:otherwise>
+        <xsl:sequence select="concat($mname, ' ', $day, ', ', $yr)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+
+  <xsl:function name="dt-local:format-dateTime-local" as="xs:string">
+    <xsl:param name="d"    as="xs:dateTime"/>
+    <xsl:param name="lang" as="xs:string"/>
+
+    <xsl:variable name="d_date" select="xs:date($d)"/>
+    <xsl:variable name="d_time" select="xs:time($d)"/>
+
+    <fo:inline>
+      <xsl:value-of select="dt-local:format-date-local($d_date, $lang)"/>
+      <xsl:value-of select="$d_time"/>
+    </fo:inline>
+  </xsl:function>
+
+  <xsl:function name="dt-local:format-date-local-tbd" as="xs:string">
+    <xsl:param name="d"    as="xs:date?"/>
+    <xsl:param name="lang" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="not(exists($d))">TBD</xsl:when>
+      <xsl:otherwise>
+        <xsl:variable name="_d" select="xs:date($d)"/>
+        <xsl:value-of select="dt-local:format-date-local($_d, $lang)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+
+  <xsl:function name="dt-local:format-dateTime-local-tbd" as="xs:string">
+    <xsl:param name="d"    as="xs:dateTime?"/>
+    <xsl:param name="lang" as="xs:string"/>
+
+    <xsl:choose>
+      <xsl:when test="not(exists($d))">TBD</xsl:when>
+      <xsl:otherwise>
+        <xsl:variable name="_d" select="xs:dateTime($d)"/>
+        <xsl:value-of select="dt-local:format-dateTime-local($_d, $lang)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+
+</xsl:stylesheet>

--- a/xslt/functions_params_vars.xslt
+++ b/xslt/functions_params_vars.xslt
@@ -2,6 +2,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
     xmlns:my="http://www.radical.sexy"
+    xmlns:dt-local="http://www.radical.sexy/schema/dt-local"
     xmlns:fo="http://www.w3.org/1999/XSL/Format"
     exclude-result-prefixes="xs my" version="2.0">
 
@@ -433,14 +434,7 @@
                 <xsl:for-each select="//version_history/version">
                     <xsl:sort select="xs:dateTime(@date)" order="descending"/>
                     <xsl:if test="position() = 1">
-                        <xsl:value-of
-                            select="format-dateTime(@date, '[MNn] [D1o], [Y]', 'en', (), ())"/>
-                        <!-- Note: this should be: 
-                    <xsl:value-of select="format-dateTime(@date, $localDateFormat, $lang, (), ())"/> 
-                    to properly be localised, but we're using Saxon HE instead of PE/EE and having localised month names 
-                    would require creating a LocalizerFactory 
-                    See http://www.saxonica.com/html/documentation/extensibility/config-extend/localizing/ for more info
-                    sounds like I'd have to know Java for that so for now, the date isn't localised. :) -->
+                        <xsl:value-of select="dt-local:format-dateTime-local-tbd(@date, $lang)"/>
                     </xsl:if>
                 </xsl:for-each>
             </xsl:otherwise>

--- a/xslt/functions_params_vars.xslt
+++ b/xslt/functions_params_vars.xslt
@@ -25,7 +25,7 @@
     <xsl:param name="EXEC_SUMMARY" select="false()"/>
 
     <!-- language parameter for localization (quote & invoice) -->
-    <xsl:param name="lang" select="/*/@xml:lang"/>
+    <xsl:param name="lang" select="(/*/@xml:lang, 'en')[1]"/>
 
     <!-- keys for numbering (used in report) -->
     <xsl:key name="rosid" match="section | finding | appendix | non-finding" use="@id"/>

--- a/xslt/localisation.xslt
+++ b/xslt/localisation.xslt
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:dt-local="http://www.radical.sexy/schema/dt-local"
     xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:fo="http://www.w3.org/1999/XSL/Format" exclude-result-prefixes="xs" version="2.0">
 
+    <xsl:include href="dates.xsl"/>
     
     <xsl:variable name="strdoc"
         select="document('../source/snippets/localisationstrings.xml')/localised_strings"/>

--- a/xslt/meta.xslt
+++ b/xslt/meta.xslt
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:dt-local="http://www.radical.sexy/schema/dt-local"
     xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="xs my"
     xmlns:fo="http://www.w3.org/1999/XSL/Format"
     xmlns:my="http://www.radical.sexy"
@@ -317,9 +318,7 @@
                             </fo:table-cell>
                             <fo:table-cell xsl:use-attribute-sets="td">
                                 <fo:block>
-                                    <xsl:value-of
-                                        select="format-dateTime(@date, '[MNn] [D1o], [Y]', 'en', (), ())"
-                                    />
+                                    <xsl:value-of select="dt-local:format-dateTime-local($date, $lang)"/>
                                 </fo:block>
                             </fo:table-cell>
                             <fo:table-cell xsl:use-attribute-sets="td">

--- a/xslt/meta.xslt
+++ b/xslt/meta.xslt
@@ -318,7 +318,7 @@
                             </fo:table-cell>
                             <fo:table-cell xsl:use-attribute-sets="td">
                                 <fo:block>
-                                    <xsl:value-of select="dt-local:format-dateTime-local($date, $lang)"/>
+                                    <xsl:value-of select="dt-local:format-dateTime-local-tbd(@date, $lang)"/>
                                 </fo:block>
                             </fo:table-cell>
                             <fo:table-cell xsl:use-attribute-sets="td">

--- a/xslt/placeholders.xslt
+++ b/xslt/placeholders.xslt
@@ -3,6 +3,7 @@
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
   xmlns:my="http://www.radical.sexy"
+  xmlns:dt-local="http://www.radical.sexy/schema/dt-local"
   exclude-result-prefixes="xs my"
   version="2.0"
 >
@@ -937,9 +938,7 @@
                               self::p_draftdue or self::p_reportdue) and string($placeholderElement) castable as xs:date"
           >
                         <!-- pretty printing for date -->
-                        <xsl:value-of
-              select="format-date($placeholderElement, '[MNn] [D1], [Y]', 'en', (), ())"
-            />
+                        <xsl:value-of select="dt-local:format-date-local-tbd($placeholderElement, $lang)"/>
                     </xsl:when>
                     <xsl:when
             test="(self::contract_end_date or


### PR DESCRIPTION
Localizes dates in Dutch, German and English (default) with custom functions.

Hardcoding the month names helps to avoid fiddling with Saxon and Java.