### PR TITLE
fix: ensure empty status does not show up in finding summary

### DIFF
--- a/xslt/auto.xslt
+++ b/xslt/auto.xslt
@@ -184,7 +184,8 @@
                 </fo:block>
    
                 <!-- Status Section -->
-                <xsl:if test="@status and @status != 'none'">
+                <xsl:if test="@status and @status != 'none' and @status != ''">
+                  
                     <fo:block>
                         <fo:inline
               xsl:use-attribute-sets="bold"


### PR DESCRIPTION
Fixes minor error, that empty status field (still) showed up in the finding summary