### PR TITLE
feat: add XSLT to convert to Markdown

### DIFF
--- a/xslt/generate_md_report.xsl
+++ b/xslt/generate_md_report.xsl
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsl:stylesheet
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:my="http://www.radical.sexy"
+  xmlns:map="http://www.w3.org/2005/xpath-functions/map"
+  exclude-result-prefixes="xs my map"
+  version="2.0"
+>
+  <xsl:import href="numbering.xslt" />
+  <xsl:import href="localisation.xslt" />
+  <xsl:import href="md_placeholders.xslt" />
+  <!-- Includes functions calculatePersonDays, generateTargets
+       Includes template VersionNumber -->
+  <xsl:import href="md_auto.xslt" />
+  <!-- Includes Markdown formatting -->
+  <xsl:import href="md_formatting.xslt" />  
+  <xsl:include href="functions_params_vars.xslt" />
+
+  <xsl:preserve-space elements="pre code" />
+  <xsl:strip-space elements="*" />
+  <xsl:output method="text" encoding="UTF-8" indent="no" />
+
+  <xsl:param name="NUMBERING" select="true()" />
+
+  <!-- Dynamically skip identifiers from the report -->
+  <xsl:variable
+    name="skip-ids"
+    select="
+        if (unparsed-text-available('../exclude-ids.txt'))
+        then tokenize(unparsed-text('../exclude-ids.txt'), '\s*,\s*|\s+')
+        else ()
+    "
+  />
+
+  <!-- Text node normalization -->
+  <xsl:template match="text()[normalize-space()][not(ancestor::pre)]">
+    <xsl:value-of select="normalize-space(.)" />
+    <xsl:if test="following-sibling::text()[normalize-space()][1]">
+      <xsl:text> </xsl:text>
+    </xsl:if>
+  </xsl:template>
+
+  <!-- Root -->
+  <xsl:template match="/">
+    <xsl:apply-templates select="/*/section | /*/appendix" />
+  </xsl:template>
+
+  <!-- Sections/Appendices -->
+  <xsl:template match="section | appendix">
+    <xsl:if test="not(@id = $skip-ids)">
+      <xsl:apply-templates select="node()" />
+    </xsl:if>
+  </xsl:template>
+
+  <!-- Findings -->
+  <xsl:template match="finding">
+    <xsl:text>&#10;### </xsl:text>
+    <xsl:value-of select="@number" />
+    <xsl:text> - </xsl:text>
+    <xsl:value-of select="title" />
+    <xsl:text>&#10;&#10;</xsl:text>
+
+    <xsl:variable
+      name="info"
+      select="map {
+            'Type': normalize-space(@type),
+            'Identifier': @id,
+            'Threat Level': @threatLevel
+        }"
+    />
+    <xsl:for-each select="map:keys($info)">
+      <xsl:call-template name="finding-section">
+        <xsl:with-param name="label" select="." />
+        <xsl:with-param name="value" select="$info(.)" />
+      </xsl:call-template>
+    </xsl:for-each>
+
+    <xsl:variable
+      name="sectionLabels"
+      select="map {
+            'description': 'Description',
+            'technicaldescription': 'Technical Description',
+            'update': 'Update',
+            'impact': 'Impact',
+            'recommendation': 'Recommendation'
+        }"
+    />
+    <xsl:for-each
+      select="description|technicaldescription|update|impact|recommendation"
+    >
+      <xsl:text>&#10;#### </xsl:text>
+      <xsl:value-of select="$sectionLabels(local-name())" />
+      <xsl:text>&#10;</xsl:text>
+      <xsl:apply-templates />
+    </xsl:for-each>
+  </xsl:template>
+
+  <xsl:template name="finding-section">
+    <xsl:param name="label" />
+    <xsl:param name="value" />
+    <xsl:text>&#10;#### </xsl:text>
+    <xsl:value-of select="$label" />
+    <xsl:text>&#10;</xsl:text>
+    <xsl:value-of select="$value" />
+    <xsl:text>&#10;</xsl:text>
+  </xsl:template>
+</xsl:stylesheet>

--- a/xslt/md_auto.xslt
+++ b/xslt/md_auto.xslt
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsl:stylesheet
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:my="http://www.radical.sexy"
+  exclude-result-prefixes="xs my"
+  version="2.0"
+>
+
+  <!-- Calculates person-days from min/max durations -->
+  <xsl:function name="my:calculatePersonDays" as="xs:string">
+    <xsl:param name="context" as="element()" />
+    <xsl:variable
+      name="durations"
+      select="$context//entry[@type='service']/dh"
+    />
+    <xsl:variable name="min" select="sum($durations/min)" />
+    <xsl:variable name="max" select="sum($durations/max)" />
+    <xsl:if test="$min != $max">
+      <xsl:value-of select="$min div 8" />
+      <xsl:text> - </xsl:text>
+      <xsl:value-of select="$max div 8" />
+    </xsl:if>
+    <xsl:if test="$min = $max">
+      <xsl:value-of select="$min div 8" />
+    </xsl:if>
+  </xsl:function>
+
+  <!-- Generates target list -->
+  <xsl:function name="my:generateTargets" as="xs:string">
+    <xsl:param name="context" as="element()" />
+    <xsl:text>&#10;</xsl:text>
+    <xsl:for-each select="$context//targets/target">
+      <xsl:text>- </xsl:text>
+      <xsl:apply-templates select="." />
+      <xsl:text>&#10;</xsl:text>
+    </xsl:for-each>
+  </xsl:function>
+
+  <!-- Generates version number (auto or explicit) -->
+  <xsl:template name="VersionNumber">
+    <xsl:param name="number" select="@number" />
+    <xsl:choose>
+      <!-- if value is auto, do some autonumbering magic -->
+      <xsl:when test="string(@number) = 'auto'">
+        0.
+        <xsl:number
+          count="version"
+          level="multiple"
+          format="{$AUTO_NUMBERING_FORMAT}"
+        />
+        <!-- this is really unrobust :D - todo: follow fixed numbering if provided -->
+      </xsl:when>
+      <xsl:otherwise>
+        <!-- just plop down the value -->
+        <!-- todo: guard numbering format in schema -->
+        <xsl:value-of select="@number" />
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+</xsl:stylesheet>

--- a/xslt/md_formatting.xslt
+++ b/xslt/md_formatting.xslt
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsl:stylesheet
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:my="http://www.radical.sexy"
+  exclude-result-prefixes="xs my"
+  version="2.0"
+>
+
+  <!-- Adds a space before punctuation or at end of text -->
+  <xsl:function name="my:addSpaceIfNeeded" as="xs:string">
+    <xsl:param name="node" as="element()" />
+    <xsl:variable
+      name="next"
+      select="
+            $node/following-sibling::node()
+            [not(self::comment() or self::processing-instruction())]
+            [normalize-space()][1]
+        "
+    />
+    <xsl:sequence
+      select="
+            if (empty($next)) then ''
+            else if ($next[self::text()][matches(., '^[,.\)]')]) then ''
+            else ' '
+        "
+    />
+  </xsl:function>
+
+  <!-- Adds a space before an element if not preceded by (, [, <, or whitespace -->
+  <xsl:function name="my:addSpaceBeforeIfNeeded" as="xs:string">
+    <xsl:param name="node" as="element()" />
+    <xsl:variable
+      name="prev"
+      select="
+            $node/preceding-sibling::node()
+            [not(self::comment() or self::processing-instruction())]
+            [normalize-space()][1]
+        "
+    />
+    <xsl:sequence
+      select="
+            if (empty($prev)) then ''
+            else if ($prev[self::text()][matches(., '(\s|[(\[{])$')]) then ''
+            else ' '
+        "
+    />
+  </xsl:function>
+  
+  <!-- Headings -->
+  <xsl:template match="title">
+    <xsl:variable
+      name="level"
+      select="count(ancestor::section | ancestor::appendix) + 1"
+    />
+    <xsl:if test="count(preceding::title) &gt; 0">
+      <xsl:text>&#10;</xsl:text>
+    </xsl:if>
+    <xsl:text>#</xsl:text>
+    <xsl:for-each select="1 to $level - 1">
+      <xsl:text>#</xsl:text>
+    </xsl:for-each>
+    <xsl:text> </xsl:text>
+    <xsl:value-of select="." />
+    <xsl:text>&#10;</xsl:text>
+  </xsl:template>
+
+  <!-- Inline elements -->
+  <xsl:template match="br">
+    <xsl:text>&#10;&#10;</xsl:text>
+  </xsl:template>
+  <xsl:template match="p">
+    <xsl:apply-templates />
+    <xsl:text>&#10;</xsl:text>
+  </xsl:template>
+
+  <xsl:template match="a">
+    <xsl:value-of select="my:addSpaceBeforeIfNeeded(.)" />
+    <xsl:text>[</xsl:text>
+    <xsl:apply-templates />
+    <xsl:text>](</xsl:text>
+    <xsl:value-of select="@href" />
+    <xsl:text>)</xsl:text>
+    <xsl:value-of select="my:addSpaceIfNeeded(.)" />
+  </xsl:template>
+
+  <xsl:template match="img">
+    <xsl:text>&#10;</xsl:text>
+    <xsl:text>![</xsl:text>
+    <xsl:value-of select="@alt" />
+    <xsl:text>](</xsl:text>
+    <xsl:value-of select="@src" />
+    <xsl:text>)</xsl:text>
+    <xsl:text>&#10;</xsl:text>
+    <xsl:value-of select="my:addSpaceIfNeeded(.)" />
+  </xsl:template>
+
+  <xsl:template match="strong|b">
+    <xsl:text>**</xsl:text>
+    <xsl:apply-templates />
+    <xsl:text>**</xsl:text>
+    <xsl:value-of select="my:addSpaceIfNeeded(.)" />
+  </xsl:template>
+
+  <xsl:template match="em|i">
+    <xsl:value-of select="my:addSpaceBeforeIfNeeded(.)" />
+    <xsl:text>*</xsl:text>
+    <xsl:value-of select="normalize-space(.)" />
+    <xsl:text>*</xsl:text>
+    <xsl:value-of select="my:addSpaceIfNeeded(.)" />
+  </xsl:template>
+
+  <xsl:template match="pre">
+    <xsl:text>&#10;&#96;&#96;&#96;&#10;</xsl:text>
+    <xsl:apply-templates select="node()" mode="codeblock" />
+    <xsl:text>&#10;&#96;&#96;&#96;&#10;</xsl:text>
+  </xsl:template>
+
+  <xsl:template match="code" mode="codeblock">
+    <xsl:apply-templates select="node()" />
+  </xsl:template>
+
+  <xsl:template match="code">
+    <xsl:text>`</xsl:text>
+    <xsl:apply-templates select="node()" />
+    <xsl:text>`</xsl:text>
+    <xsl:value-of select="my:addSpaceIfNeeded(.)" />
+  </xsl:template>
+
+  <!-- Lists -->
+  <xsl:template match="ul">
+    <xsl:text>&#10;</xsl:text>
+    <xsl:apply-templates select="li" />
+  </xsl:template>
+
+  <xsl:template match="li">
+    <xsl:text>- </xsl:text>
+    <xsl:apply-templates />
+    <xsl:text>&#10;</xsl:text>
+  </xsl:template>
+</xsl:stylesheet>

--- a/xslt/md_placeholders.xslt
+++ b/xslt/md_placeholders.xslt
@@ -1,0 +1,1239 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsl:stylesheet
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:my="http://www.radical.sexy"
+  exclude-result-prefixes="xs my"
+  version="2.0"
+>
+<!-- Markdown-styled placeholders. Several items receive a forced space -->    
+    <xsl:template name="displayErrorText">
+        <xsl:param name="string" select="'XXXXXXXXXX'" />
+        <xsl:text>*</xsl:text><xsl:value-of select="$string" />        <xsl:text
+    >*</xsl:text>
+    </xsl:template>
+
+    <xsl:template name="getDenomination">
+        <xsl:param name="placeholderElement" as="node()" select="/" />
+        <xsl:choose>
+            <xsl:when
+        test="$placeholderElement/ancestor-or-self::*[@denomination][1]/@denomination = 'eur'"
+      >
+                <xsl:text>€ </xsl:text>
+            </xsl:when>
+            <xsl:when
+        test="$placeholderElement/ancestor-or-self::*[@denomination][1]/@denomination = 'usd'"
+      >
+                <xsl:text>$ </xsl:text>
+            </xsl:when>
+            <xsl:when
+        test="$placeholderElement/ancestor-or-self::*[@denomination][1]/@denomination = 'gbp'"
+      >
+                <xsl:text>£ </xsl:text>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:call-template name="displayErrorText">
+                    <xsl:with-param
+            name="string"
+          >WARNING: NO DENOMINATION FOUND</xsl:with-param>
+                </xsl:call-template>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>    
+
+    <!-- PLACEHOLDERS -->
+    <xsl:template match="latest_version_date">
+        <xsl:value-of select="$latestVersionDate" />
+    </xsl:template>
+    <xsl:template match="client_long">
+        <xsl:param
+      name="placeholderElement"
+      select="/*/meta//client/full_name"
+    />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+    <xsl:value-of select="my:addSpaceIfNeeded(.)" />        
+    </xsl:template>
+    <xsl:template match="client_short">
+        <xsl:param
+      name="placeholderElement"
+      select="/*/meta//client/short_name"
+    />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+    <xsl:value-of select="my:addSpaceIfNeeded(.)" />        
+    </xsl:template>
+    <xsl:template match="client_street">
+        <xsl:param name="placeholderElement" select="/*/meta//client/address" />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="client_city">
+        <xsl:param name="placeholderElement" select="/*/meta//client/city" />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="client_country">
+        <xsl:param name="placeholderElement" select="/*/meta//client/country" />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="client_postal_code">
+        <xsl:param
+      name="placeholderElement"
+      select="/*/meta//client/postal_code"
+    />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="client_legal_rep">
+        <xsl:param
+      name="placeholderElement"
+      select="/*/meta//client/legal_rep"
+    />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="client_waiver_rep">
+        <xsl:param
+      name="placeholderElement"
+      select="/*/meta//client/waiver_rep"
+    />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="client_poc1">
+        <xsl:param name="placeholderElement" select="/*/meta//client/poc1" />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="client_coc">
+        <xsl:param name="placeholderElement" select="/*/meta//client/coc" />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="client_ref">
+        <xsl:param
+      name="placeholderElement"
+      select="/*/meta/client_reference"
+    />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="client_rate">
+        <xsl:param name="roleTitle" select="@title" />
+        <xsl:param
+      name="placeholderElement"
+      select="/*/meta//client/rates/rate[@title = $roleTitle]"
+    />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="company_long">
+        <xsl:param
+      name="placeholderElement"
+      select="/*/meta/company/full_name"
+    />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+    <xsl:value-of select="my:addSpaceIfNeeded(.)" />
+    </xsl:template>
+    <xsl:template match="company_short">
+        <xsl:param
+      name="placeholderElement"
+      select="/*/meta/company/short_name"
+    />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+    <xsl:value-of select="my:addSpaceIfNeeded(.)" />
+    </xsl:template>
+    <xsl:template match="company_address">
+        <xsl:param name="placeholderElement" select="/*/meta/company/address" />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="company_city">
+        <xsl:param name="placeholderElement" select="/*/meta/company/city" />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="company_postalcode">
+        <xsl:param
+      name="placeholderElement"
+      select="/*/meta/company/postal_code"
+    />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="company_country">
+        <xsl:param name="placeholderElement" select="/*/meta/company/country" />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="company_svc_long">
+        <xsl:param
+      name="placeholderElement"
+      select="/offerte/meta/offered_service_long | /pentest_report/meta/offered_service_long"
+    />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+    <xsl:value-of select="my:addSpaceIfNeeded(.)" />        
+    </xsl:template>
+    <xsl:template match="company_svc_short">
+        <xsl:param
+      name="placeholderElement"
+      select="/offerte/meta/offered_service_short | /pentest_report/meta/offered_service_short"
+    />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+            <xsl:value-of select="my:addSpaceIfNeeded(.)" />
+    </xsl:template>
+    <xsl:template match="company_legal_rep">
+        <xsl:param
+      name="placeholderElement"
+      select="/*/meta/company/legal_rep"
+    />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="company_poc1">
+        <xsl:param name="placeholderElement" select="/*/meta/company/poc1" />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="company_email">
+        <xsl:param name="placeholderElement" select="/*/meta/company/email" />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="t_app">
+        <xsl:param
+      name="placeholderElement"
+      select="/offerte/meta/activityinfo/target_application | /pentest_report/meta/activityinfo/target_application"
+    />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+    <xsl:value-of select="my:addSpaceIfNeeded(.)" />        
+    </xsl:template>
+    <xsl:template match="t_app_producer">
+        <xsl:param
+      name="placeholderElement"
+      select="/offerte/meta/activityinfo/target_application_producer | /pentest_report/meta/activityinfo/target_application_producer"
+    />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="p_persondays">
+        <xsl:param
+      name="placeholderElement"
+      select="/*/meta/activityinfo/persondays"
+    />
+        <xsl:choose>
+            <xsl:when
+        test="$placeholderElement = '' or $placeholderElement = '0' or not($placeholderElement)"
+      >
+                <xsl:call-template name="calculatePersonDays" />
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:call-template name="checkPlaceholder">
+                    <xsl:with-param
+            name="placeholderElement"
+            select="$placeholderElement"
+          />
+                </xsl:call-template>
+            </xsl:otherwise>
+        </xsl:choose>
+    <xsl:value-of select="my:addSpaceIfNeeded(.)" />        
+    </xsl:template>
+    <xsl:template match="p_boxtype">
+        <xsl:param
+      name="placeholderElement"
+      select="/*/meta/activityinfo/type"
+    />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+            <xsl:value-of select="my:addSpaceIfNeeded(.)" />
+    </xsl:template>
+    <xsl:template match="p_fee">
+        <xsl:param
+      name="placeholderElement"
+      select="/*/meta/activityinfo/fee"
+    />
+        <xsl:choose>
+            <xsl:when
+        test="$placeholderElement = '' or $placeholderElement = '0' or not($placeholderElement)"
+      >
+                <xsl:call-template name="calculateTotal" />
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:call-template name="getDenomination">
+                    <xsl:with-param
+            name="placeholderElement"
+            select="$placeholderElement"
+          />
+                </xsl:call-template>
+                <xsl:text>&#160;</xsl:text>
+                <xsl:call-template name="checkPlaceholder">
+                    <xsl:with-param
+            name="placeholderElement"
+            select="$placeholderElement"
+          />
+                </xsl:call-template>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+    <xsl:template match="p_startdate">
+        <xsl:param
+      name="placeholderElement"
+      select="/*/meta/activityinfo/planning/start"
+    />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+        <xsl:value-of select="my:addSpaceIfNeeded(.)" />
+    </xsl:template>
+    <xsl:template match="p_enddate">
+        <xsl:param
+      name="placeholderElement"
+      select="/*/meta/activityinfo/planning/end"
+    />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+    <xsl:value-of select="my:addSpaceIfNeeded(.)" />
+    </xsl:template>
+    <xsl:template match="p_draftdue">
+        <xsl:param
+      name="placeholderElement"
+      select="/*/meta/activityinfo/draft"
+    />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="p_reportdue">
+        <xsl:param
+      name="placeholderElement"
+      select="/*/meta/activityinfo/report_due"
+    />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="engagement_description">
+        <xsl:param
+      name="placeholderElement"
+      select="/contract/meta/scope/engagement_description"
+    />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="secondpartyrole">
+        <xsl:param
+      name="placeholderElement"
+      select="/contract/meta/scope/secondpartyrole"
+    />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="contract_start_date">
+        <xsl:param
+      name="placeholderElement"
+      select="/contract/meta/work/start_date"
+    />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="contract_end_date">
+        <xsl:param
+      name="placeholderElement"
+      select="/contract/meta/work/end_date"
+    />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="contract_period">
+        <xsl:variable
+      name="startDate"
+      select="xs:date(/contract/meta/work/start_date)"
+    />
+        <xsl:variable
+      name="endDate"
+      select="xs:date(/contract/meta/work/end_date)"
+    />
+        <!--<xsl:variable name="startDay" as="xs:integer" select="day-from-date($startDate)"/>
+        <xsl:variable name="endDay" as="xs:integer" select="day-from-date($endDate)"/>-->
+        <xsl:value-of select="my:calculatePeriod($endDate, $startDate)" />
+    </xsl:template>
+    <xsl:template match="contract_total_fee">
+        <xsl:call-template name="getDenomination" />
+        <xsl:text>&#160;</xsl:text>
+        <xsl:value-of select="$total_fee" />
+        <!-- no need to check for existence as it's a calculation of two checked values below -->
+    </xsl:template>
+    <xsl:template match="contract_planned_hours">
+        <xsl:param
+      name="placeholderElement"
+      select="/contract/meta/work/planning/hours"
+    />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="contract_period_unit">
+        <xsl:param
+      name="placeholderElement"
+      select="/contract/meta/work/planning/per"
+    />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+    </xsl:template>
+    <!--
+    <xsl:template match="contract_activities">
+        <xsl:choose>
+            <xsl:when test="/contract/meta/work/activities/activity">
+                <xsl:call-template name="generate_activities" />
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:call-template name="displayErrorText">
+                    <xsl:with-param
+            name="string"
+          >WARNING: NO ACTIVITIES FOUND</xsl:with-param>
+                </xsl:call-template>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template> -->
+    <xsl:template match="contractor_name_company">
+        <xsl:param
+      name="placeholderElement"
+      select="/contract/meta/contractor/name"
+    />
+        <xsl:param
+      name="placeholderElement2"
+      select="/contract/meta/contractor/ctcompany"
+    />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+        <xsl:if test="/contract/meta/contractor/ctcompany">
+            <xsl:text> (</xsl:text>
+            <xsl:call-template name="checkPlaceholder">
+                <xsl:with-param
+          name="placeholderElement"
+          select="$placeholderElement2"
+        />
+            </xsl:call-template>
+            <xsl:text>)</xsl:text>
+        </xsl:if>
+    </xsl:template>
+    <xsl:template match="contractor_name">
+        <xsl:param
+      name="placeholderElement"
+      select="/contract/meta/contractor/name"
+    />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="contractor_company">
+        <xsl:param
+      name="placeholderElement"
+      select="/contract/meta/contractor/ctcompany"
+    />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="contractor_address">
+        <xsl:param
+      name="placeholderElement"
+      select="/contract/meta/contractor/address"
+    />
+        <xsl:param name="caps" select="@caps" />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+            <xsl:with-param name="caps" select="$caps" />
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="contractor_city">
+        <xsl:param
+      name="placeholderElement"
+      select="/contract/meta/contractor/city"
+    />
+        <xsl:param name="caps" select="@caps" />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+            <xsl:with-param name="caps" select="$caps" />
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="contractor_postalcode">
+        <xsl:param
+      name="placeholderElement"
+      select="/contract/meta/contractor/postal_code"
+    />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="contractor_country">
+        <xsl:param
+      name="placeholderElement"
+      select="/contract/meta/contractor/country"
+    />
+        <xsl:param name="caps" select="@caps" />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+            <xsl:with-param name="caps" select="$caps" />
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="contractor_hourly_fee">
+        <xsl:param
+      name="placeholderElement"
+      select="/contract/meta/contractor/hourly_fee"
+    />
+        <xsl:call-template name="getDenomination">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+        <xsl:text>&#160;</xsl:text>
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="contractor_email">
+        <xsl:param
+      name="placeholderElement"
+      select="/contract/meta/contractor/email"
+    />
+        <xsl:param name="caps" select="@caps" />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+            <xsl:with-param name="caps" select="$caps" />
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="contractor_possessive_pronoun">
+        <xsl:param
+      name="placeholderElement"
+      select="/contract/meta/contractor/@sex"
+    />
+        <xsl:param name="caps" select="@caps" />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+            <xsl:with-param name="caps" select="$caps" />
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="contractor_subject_pronoun">
+        <xsl:param
+      name="placeholderElement"
+      select="/contract/meta/contractor/@sex"
+    />
+        <xsl:param name="caps" select="@caps" />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+            <xsl:with-param name="caps" select="$caps" />
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="contractor_object_pronoun">
+        <xsl:param
+      name="placeholderElement"
+      select="/contract/meta/contractor/@sex"
+    />
+        <xsl:param name="caps" select="@caps" />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+            <xsl:with-param name="caps" select="$caps" />
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="generate_raterevisiondate">
+        <xsl:param
+      name="placeholderElement"
+      select="//meta//client/rates/@lastrevisiondate"
+    />
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="ir_ora_rate">
+        <xsl:param
+      name="placeholderElement"
+      select="/*/meta/activityinfo/organizational_readiness_assessment/rate"
+    />
+        <xsl:call-template name="getDenomination">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+        <xsl:text>&#160;</xsl:text>
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="ir_sim_rate">
+        <xsl:param
+      name="placeholderElement"
+      select="/*/meta/activityinfo/security_incident_management/rate"
+    />
+        <xsl:call-template name="getDenomination">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+        <xsl:text>&#160;</xsl:text>
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="ir_taa_rate">
+        <xsl:param
+      name="placeholderElement"
+      select="/*/meta/activityinfo/technical_artefact_analysis/rate"
+    />
+        <xsl:call-template name="getDenomination">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+        <xsl:text>&#160;</xsl:text>
+        <xsl:call-template name="checkPlaceholder">
+            <xsl:with-param
+        name="placeholderElement"
+        select="$placeholderElement"
+      />
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="finding_count">
+        <xsl:param name="threatLevel" select="@threatLevel" />
+        <xsl:variable name="statusSequence" as="item()*">
+            <xsl:for-each select="@status">
+                <xsl:for-each select="tokenize(., ' ')">
+                    <xsl:value-of select="." />
+                </xsl:for-each>
+            </xsl:for-each>
+        </xsl:variable>
+        <xsl:choose>
+            <xsl:when test="@status and @threatLevel">
+                <!-- Only generate a count for findings with these statuses AND this threatLevel -->
+                <xsl:value-of
+          select="
+                        count(//finding[@threatLevel =
+                        $threatLevel][@status =
+                        $statusSequence])"
+        />
+                <xsl:text> </xsl:text>
+                <xsl:value-of select="@threatLevel" />
+            </xsl:when>
+            <xsl:when test="@status and not(@threatLevel)">
+                <!-- Only generate a count for findings with these statuses -->
+                <xsl:for-each-group
+          select="
+                        //finding[@status =
+                        $statusSequence]"
+          group-by="@threatLevel"
+        >
+                  <xsl:call-template name="print_threatlevel_counts">
+                    <xsl:with-param
+              name="threatLevels"
+              select="count(distinct-values(//finding[@status
+                                            = $statusSequence]/@threatLevel))"
+              as="xs:integer"
+            />
+                  </xsl:call-template>
+                </xsl:for-each-group>
+            </xsl:when>
+            <xsl:when test="@threatLevel and not(@status)">
+                <!-- Only generate a count for findings with this threatLevel -->
+                <xsl:value-of
+          select="count(//finding[@threatLevel = $threatLevel])"
+        />
+                <xsl:text> </xsl:text>
+                <xsl:value-of select="@threatLevel" />
+            </xsl:when>
+            <xsl:otherwise>
+                <!-- all statuses, all threatLevels -->
+                <xsl:for-each-group select="//finding" group-by="@threatLevel">
+                  <xsl:call-template name="print_threatlevel_counts">
+                    <xsl:with-param
+              name="threatLevels"
+              select="count(distinct-values(//finding/@threatLevel))"
+              as="xs:integer"
+            />
+                  </xsl:call-template>
+                </xsl:for-each-group>
+            </xsl:otherwise>
+        </xsl:choose>
+      <xsl:value-of select="my:addSpaceIfNeeded(.)" />
+    </xsl:template>
+
+    <xsl:template name="print_threatlevel_counts">
+      <xsl:param name="threatLevels" />
+        <xsl:value-of select="count(current-group())" />
+        <xsl:text> </xsl:text>
+        <xsl:value-of select="current-grouping-key()" />
+        <xsl:if test="$threatLevels != 1 and not(position() = last())">
+            <xsl:choose>
+                <xsl:when test="position() = $threatLevels - 1">
+                    <xsl:text> and </xsl:text>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:text>, </xsl:text>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:if>
+    </xsl:template>
+
+    <xsl:template name="checkPlaceholder">
+        <xsl:param name="placeholderElement" select="/" />
+        <xsl:param name="caps" select="'none'" />
+        <xsl:choose>
+            <xsl:when test="normalize-space($placeholderElement)">
+                <!-- placeholder exists and contains text -->
+                <xsl:choose>
+                    <xsl:when test="self::client_rate">
+                        <xsl:call-template name="getDenomination">
+                            <xsl:with-param
+                name="placeholderElement"
+                select="$placeholderElement"
+              />
+                        </xsl:call-template>
+                        <xsl:text>&#160;</xsl:text>
+                        <xsl:value-of select="$placeholderElement" />
+                    </xsl:when>
+                    <!-- PRETTY FORMATTING FOR AMOUNTS OF MONEY -->
+                    <xsl:when
+            test="(self::p_fee or self::contractor_hourly_fee or self::ir_ora_rate) and string($placeholderElement) castable as xs:float"
+          >
+                        <xsl:variable
+              name="fee"
+              select="$placeholderElement * 1"
+            />
+                        <xsl:number
+              value="$fee"
+              grouping-separator=","
+              grouping-size="3"
+            />
+                    </xsl:when>
+                    <!-- PRETTY FORMATTING FOR DATES -->
+                    <xsl:when
+            test="(self::contract_end_date or
+                              self::contract_start_date or
+                              self::generate_raterevisiondate or
+                              self::p_startdate or self::p_enddate or
+                              self::p_draftdue or self::p_reportdue) and string($placeholderElement) castable as xs:date"
+          >
+                        <!-- pretty printing for date -->
+                        <xsl:value-of
+              select="format-date($placeholderElement, '[MNn] [D1], [Y]', 'en', (), ())"
+            />
+                    </xsl:when>
+                    <xsl:when
+            test="(self::contract_end_date or
+                              self::contract_start_date or
+                              self::generate_raterevisiondate or
+                              self::p_startdate or self::p_enddate or
+                              self::p_draftdue or self::p_reportdue) and normalize-space(.) = 'TBD'"
+          >
+                        <!-- actual TBD, don't mess with it --> TBD </xsl:when>
+                    <xsl:when
+            test="(self::contract_end_date or self::contract_start_date or self::generate_raterevisiondate or self::p_startdate or self::p_enddate or self::p_reportdue) and not(string($placeholderElement) castable as xs:date)"
+          >
+                        <xsl:call-template name="displayErrorText">
+                            <xsl:with-param name="string">TBD</xsl:with-param>
+                        </xsl:call-template>
+                    </xsl:when>
+                    <xsl:when
+            test="self::contract_period_unit and /contract/meta/scope/contract_type = 'single_engagement'"
+          >
+                        <!-- only use value for fixed term contracts; use 'engagement' for single engagement contract -->
+                        <xsl:call-template name="getString">
+                            <xsl:with-param
+                name="stringID"
+                select="'contract_engagement'"
+              />
+                        </xsl:call-template>
+                    </xsl:when>
+                    <xsl:when test="self::contractor_possessive_pronoun">
+                        <!-- some sexy logic -->
+                        <xsl:choose>
+                            <xsl:when test="//contractor/@sex = 'M'">
+                                <xsl:call-template name="getString">
+                                    <xsl:with-param
+                    name="stringID"
+                    select="'possessive_m'"
+                  />
+                                    <xsl:with-param
+                    name="caps"
+                    select="$caps"
+                  />
+                                </xsl:call-template>
+                            </xsl:when>
+                            <xsl:when test="//contractor/@sex = 'F'">
+                                <xsl:call-template name="getString">
+                                    <xsl:with-param
+                    name="stringID"
+                    select="'possessive_f'"
+                  />
+                                    <xsl:with-param
+                    name="caps"
+                    select="$caps"
+                  />
+                                </xsl:call-template>
+                            </xsl:when>
+                            <xsl:when test="//contractor/@sex = 'O'">
+                                <xsl:call-template name="getString">
+                                    <xsl:with-param
+                    name="stringID"
+                    select="'possessive_o'"
+                  />
+                                    <xsl:with-param
+                    name="caps"
+                    select="$caps"
+                  />
+                                </xsl:call-template>
+                            </xsl:when>
+                        </xsl:choose>
+                    </xsl:when>
+                    <xsl:when test="self::contractor_subject_pronoun">
+                        <!-- some sexy logic -->
+                        <xsl:choose>
+                            <xsl:when test="//contractor/@sex = 'M'">
+                                <xsl:call-template name="getString">
+                                    <xsl:with-param
+                    name="stringID"
+                    select="'subject_m'"
+                  />
+                                    <xsl:with-param
+                    name="caps"
+                    select="$caps"
+                  />
+                                </xsl:call-template>
+                            </xsl:when>
+                            <xsl:when test="//contractor/@sex = 'F'">
+                                <xsl:call-template name="getString">
+                                    <xsl:with-param
+                    name="stringID"
+                    select="'subject_f'"
+                  />
+                                    <xsl:with-param
+                    name="caps"
+                    select="$caps"
+                  />
+                                </xsl:call-template>
+                            </xsl:when>
+                            <xsl:when test="//contractor/@sex = 'O'">
+                                <xsl:call-template name="getString">
+                                    <xsl:with-param
+                    name="stringID"
+                    select="'subject_o'"
+                  />
+                                    <xsl:with-param
+                    name="caps"
+                    select="$caps"
+                  />
+                                </xsl:call-template>
+                            </xsl:when>
+                        </xsl:choose>
+                    </xsl:when>
+                    <xsl:when test="self::contractor_object_pronoun">
+                        <!-- some sexy logic -->
+                        <xsl:choose>
+                            <xsl:when test="//contractor/@sex = 'M'">
+                                <xsl:call-template name="getString">
+                                    <xsl:with-param
+                    name="stringID"
+                    select="'object_m'"
+                  />
+                                    <xsl:with-param
+                    name="caps"
+                    select="$caps"
+                  />
+                                </xsl:call-template>
+                            </xsl:when>
+                            <xsl:when test="//contractor/@sex = 'F'">
+                                <xsl:call-template name="getString">
+                                    <xsl:with-param
+                    name="stringID"
+                    select="'object_f'"
+                  />
+                                    <xsl:with-param
+                    name="caps"
+                    select="$caps"
+                  />
+                                </xsl:call-template>
+                            </xsl:when>
+                            <xsl:when test="//contractor/@sex = 'O'">
+                                <xsl:call-template name="getString">
+                                    <xsl:with-param
+                    name="stringID"
+                    select="'object_o'"
+                  />
+                                    <xsl:with-param
+                    name="caps"
+                    select="$caps"
+                  />
+                                </xsl:call-template>
+                            </xsl:when>
+                        </xsl:choose>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:value-of select="$placeholderElement" />
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:call-template name="displayErrorText">
+                    <xsl:with-param
+            name="string"
+          >[ WARNING: Cannot resolve placeholder
+                            <xsl:value-of select="name()" /> in <xsl:value-of
+              select="base-uri()"
+            /> -
+                            <xsl:call-template name="getReason"><xsl:with-param
+                name="placeholderElement"
+                select="$placeholderElement"
+              /></xsl:call-template> ]</xsl:with-param>
+                </xsl:call-template>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+    <xsl:template name="getReason">
+        <xsl:param name="placeholderElement" select="." />
+        <xsl:choose>
+            <xsl:when test="/$placeholderElement"> element "<xsl:value-of
+          select="name($placeholderElement)"
+        />" (<xsl:call-template name="getXPath"><xsl:with-param
+            name="element"
+            select="$placeholderElement"
+          /></xsl:call-template>) is empty </xsl:when>
+            <xsl:otherwise> referenced element not found </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+    <xsl:template name="getXPath">
+        <xsl:param name="element" select="." />
+        <xsl:for-each select="$element/ancestor-or-self::*">
+            <xsl:value-of select="concat('/', local-name())" />
+            <!--Predicate is only output when needed.-->
+            <xsl:if
+        test="(preceding-sibling::* | following-sibling::*)[local-name() = local-name(current())]"
+      >
+                <xsl:value-of
+          select="concat('[', count(preceding-sibling::*[local-name() = local-name(current())]) + 1, ']')"
+        />
+            </xsl:if>
+        </xsl:for-each>
+    </xsl:template>
+
+    <xsl:template name="checkDenomination">
+        <xsl:param name="allDenominationsAreEqual" />
+        <xsl:param name="denoms" />
+        <xsl:choose>
+            <xsl:when test="$allDenominationsAreEqual">
+                <xsl:call-template name="getDenomination">
+                    <xsl:with-param
+            name="placeholderElement"
+            select="$denoms/denom"
+          />
+                </xsl:call-template>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:call-template name="displayErrorText">
+                    <xsl:with-param
+            name="string"
+          >Cannot print denomination: not all fees in
+                        service_breakdown have an equal denomination (tip: if most services are in
+                        eur but one is in usd, add the usd fee to the description for that service
+                        and use an estimated eur for the hourly rate or fee).</xsl:with-param>
+                </xsl:call-template>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template name="calculatePersonDays">
+        <xsl:variable
+      name="totalMinDurations"
+      select="sum($serviceNodeSet/entry[@type = 'service']/dh/min)"
+    />
+        <xsl:variable
+      name="totalMaxDurations"
+      select="sum($serviceNodeSet/entry[@type = 'service']/dh/max)"
+    />
+        <xsl:choose>
+            <xsl:when test="not($totalMinDurations = $totalMaxDurations)">
+                <xsl:value-of select="sum($totalMinDurations) div 8" />
+                <xsl:text> - </xsl:text>
+                <xsl:value-of select="sum($totalMaxDurations) div 8" />
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="sum($totalMinDurations) div 8" />
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template name="prettyMissingDecimal">
+        <xsl:param name="n" />
+        <xsl:if test="floor($n) = $n">
+            <xsl:number value="$n" grouping-separator="," grouping-size="3" />
+            <xsl:text>.-</xsl:text>
+        </xsl:if>
+    </xsl:template>
+
+    <xsl:template name="calculateTotal">
+        <xsl:param name="denoms" tunnel="yes">
+            <xsl:for-each-group
+        select="$serviceNodeSet/entry"
+        group-by="@denomination"
+      >
+                <denom denomination="{current-grouping-key()}" />
+            </xsl:for-each-group>
+        </xsl:param>
+        <xsl:variable
+      name="allDenominationsAreEqual"
+      select="count($denoms/denom) = 1"
+    />
+        <xsl:variable
+      name="minmaxesPresent"
+      select="boolean($serviceNodeSet/entry/f/min and $serviceNodeSet/entry/f/max)"
+    />
+        <xsl:variable
+      name="estimatePresent"
+      select="$serviceNodeSet/entry/@estimate"
+    />
+        <xsl:variable
+      name="totalMinFees"
+      select="sum($serviceNodeSet/entry/f/min)"
+    />
+        <xsl:variable
+      name="totalMaxFees"
+      select="sum($serviceNodeSet/entry/f/max)"
+    />
+        <xsl:choose>
+            <xsl:when test="not($totalMinFees = $totalMaxFees)">
+                <!-- We have different min and max fees, print range -->
+                <xsl:call-template name="checkDenomination">
+                    <xsl:with-param
+            name="allDenominationsAreEqual"
+            select="$allDenominationsAreEqual"
+          />
+                    <xsl:with-param name="denoms" select="$denoms" />
+                </xsl:call-template>
+                <xsl:number
+          value="$totalMinFees"
+          grouping-separator=","
+          grouping-size="3"
+        />
+                <xsl:text> - </xsl:text>
+                <xsl:call-template name="checkDenomination">
+                    <xsl:with-param
+            name="allDenominationsAreEqual"
+            select="$allDenominationsAreEqual"
+          />
+                    <xsl:with-param name="denoms" select="$denoms" />
+                </xsl:call-template>
+                <xsl:call-template name="prettyMissingDecimal">
+                    <xsl:with-param name="n" select="$totalMaxFees" />
+                </xsl:call-template>
+            </xsl:when>
+            <xsl:otherwise>
+                <!-- Min and max are equal; print single price -->
+                <xsl:call-template name="checkDenomination">
+                    <xsl:with-param
+            name="allDenominationsAreEqual"
+            select="$allDenominationsAreEqual"
+          />
+                    <xsl:with-param name="denoms" select="$denoms" />
+                </xsl:call-template>
+                <xsl:call-template name="prettyMissingDecimal">
+                    <xsl:with-param name="n" select="$totalMinFees" />
+                </xsl:call-template>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>    
+</xsl:stylesheet>


### PR DESCRIPTION
These XSLT files convert a report into Markdown format. Note that the Makefile hasn't been touched, as that's a pretty old vanilla one.
Example to create a `target/report.md`:
```
# Create Markdown from XML
$(TARGET)/%.md: source/%.xml $(SOURCE) $(TARGET)
	@$(JAVA) -jar saxon.jar \
	net.sf.saxon.Transform \
	     -s:source/report.xml \
	     -xsl:"xslt/generate_md_$*.xsl" \
	     -xi > "$@"
```