### PR TITLE
fix(dtd): correct schema gaps so valid documents validate

### DIFF
--- a/dtd/common.xsd
+++ b/dtd/common.xsd
@@ -644,7 +644,6 @@
   <xs:element name="org" type="xs:string" />
   <xs:element name="journal" type="xs:string" />
   <xs:element name="info" type="xs:string" />
-  <xs:element name="location" type="xs:string" />
   <xs:element name="pubdate" type="xs:string" />
   <xs:element name="accessed" type="xs:date" />
 

--- a/dtd/offerte.xsd
+++ b/dtd/offerte.xsd
@@ -60,6 +60,9 @@
         <xs:element minOccurs="0" ref="target_application"/>
         <xs:element minOccurs="0" ref="target_application_producer"/>
         <xs:element ref="breakdown" minOccurs="0"/>
+        <xs:element ref="participants" minOccurs="0"/>
+        <xs:element ref="location" minOccurs="0"/>
+        <xs:element ref="duration" minOccurs="0"/>
       </xs:all>
     </xs:complexType>
   </xs:element>
@@ -276,6 +279,10 @@
       <xs:element name="p_reportdue"/>
       <xs:element name="p_startdate"/>
       <xs:element name="p_enddate"/>
+      <xs:element name="p_draftdue"/>
+      <xs:element name="p_duration"/>
+      <xs:element name="p_location"/>
+      <xs:element name="p_participants"/>
       <xs:element name="signee_long"/>
       <xs:element name="signee_short"/>
       <xs:element name="signee_street"/>

--- a/dtd/pentestreport.xsd
+++ b/dtd/pentestreport.xsd
@@ -130,6 +130,7 @@
           <xs:element ref="generate_testteam"/>
           <xs:element name="p" type="block"/>
           <xs:element ref="pre"/>
+          <xs:element ref="code"/>
           <xs:element ref="table"/>
           <xs:element ref="ol"/>
           <xs:element ref="ul"/>
@@ -164,6 +165,7 @@
         <xs:element ref="title"/>
         <xs:choice minOccurs="0" maxOccurs="unbounded">
           <xs:element ref="pre"/>
+          <xs:element ref="code"/>
           <xs:element name="p" type="block"/>
           <xs:element ref="blockquote"/>
           <xs:element ref="section"/>
@@ -308,7 +310,7 @@
           <xs:element ref="description_summary"/>
         </xs:choice>
         <xs:element ref="technicaldescription"/>
-        <xs:element ref="impact"/>
+        <xs:element ref="impact" minOccurs="0"/>
         <xs:element ref="recommendation"/>
         <xs:choice minOccurs="0" maxOccurs="1">
           <xs:element ref="recommendation_summary"/>
@@ -324,6 +326,7 @@
       <xs:attribute ref="status" use="optional"/>
       <xs:attribute name="type" use="required"/>
       <xs:attribute name="number" use="required" type="xs:integer"/>
+      <xs:attribute name="prefix" use="optional" type="xs:string"/>
       <xs:attribute name="break" use="optional">
         <xs:simpleType>
           <xs:restriction base="xs:string">
@@ -366,6 +369,7 @@
         <xs:element name="img"/>
         <xs:element name="table"/>
         <xs:element ref="pre"/>
+        <xs:element ref="code"/>
         <xs:element ref="h2"/>
         <xs:element ref="h3"/>
         <xs:element ref="h4"/>


### PR DESCRIPTION
The XSD schemas were stricter and less complete than the tooling and templates, so valid PenText documents failed XSD validation. Align the schemas with what the XSLT actually supports:

- common.xsd: remove the duplicate global 'location' element.
- pentestreport.xsd: make finding @prefix optional, make <impact> optional, and allow <code> in technicaldescription, section and appendix.
- offerte.xsd: add the placeholder elements the stylesheet resolves (p_draftdue, p_duration, p_location, p_participants) and allow participants, location and duration inside activityinfo.

Schema-only change; every edit is a relaxation or addition, so documents that validated before still validate.