### PR TITLE
fix(examples): make example documents schema-valid and resolvable

### DIFF
--- a/doc/examples/client_info.xml
+++ b/doc/examples/client_info.xml
@@ -1,0 +1,1 @@
+../../source/client_info.xml

--- a/doc/examples/examplefinding.xml
+++ b/doc/examples/examplefinding.xml
@@ -1,18 +1,20 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<finding threatLevel="Moderate" type="Escalation">
+<?xml version="1.0" encoding="utf-8"?>
+<finding threatLevel="Moderate"
+         type="Escalation"
+>
   <title>Example Title</title>
-    <description>
+  <description>
         A specialized piece of malware can be crafted to bypass local anti-virus software and to cheat during tests.
     </description>
-    <technicaldescription>
+  <technicaldescription>
         The student desks run antivirus software that will prevent many common remote access and malware tools that students may use to try and cheat. It is however still possible to use common tools to evade detection by the anti-virus software. Note that to run the custom malware, a student needs to have found an arbitrary file execution bug first.
-        
+
         To exploit this vulnerability, we used 'veil-evasion' to build an undetected Meterpreter reverse TCP executable that connects back to an external computer and allows for remote access. See https://www.veil-framework.com/veil-tutorial/ for details.
     </technicaldescription>
-    <impact>
+  <impact>
         A student may use this malware to have an accomplice at a remote location assist in the test by viewing screenshots of the student desk and reading/modifying files on the student desk. The setup for this can be done very quickly - before the  test even starts - and will leave no obvious visible clues that something fishy has happened.
     </impact>
-    <recommendation>
+  <recommendation>
         Allow only a set of whitelisted programs to be executed. Base restrictions on file contents, e.g. by comparing agains one or more strong file hashes.
     </recommendation>
 </finding>

--- a/doc/examples/examplegenericdocument.xml
+++ b/doc/examples/examplegenericdocument.xml
@@ -1,101 +1,123 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<generic_document xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../dtd/genericdocument.xsd">
-        <meta>
-                <title>Generic Document</title>
-                <subtitle>It can be about ANYTHING you want!</subtitle>
-                <collaborators>
-                        <reviewers>
-                                <reviewer>Melanie Rieback</reviewer>
-                        </reviewers>
-                        <approver>
-                                <name>Melanie Rieback</name>
-                                <bio>Melanie Rieback is a former Asst. Prof. of Computer Science from the VU,
+<?xml version="1.0" encoding="utf-8"?>
+<generic_document xmlns:xi="http://www.w3.org/2001/XInclude"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:noNamespaceSchemaLocation="../dtd/genericdocument.xsd"
+>
+  <meta>
+    <title>Generic Document</title>
+    <subtitle>It can be about ANYTHING you want!</subtitle>
+    <collaborators>
+      <reviewers>
+        <reviewer>Melanie Rieback</reviewer>
+      </reviewers>
+      <approver>
+        <name>Melanie Rieback</name>
+        <bio>Melanie Rieback is a former Asst. Prof. of Computer Science from the VU,
 who is also the co-founder/CEO of Radically Open Security.</bio>
-                        </approver>
-                </collaborators>
-                <classification>Confidential</classification>
-                <version_history>
-                        <version date="2015-01-19T01:00:00" number="auto">
-                                <v_author>Patricia Piolon</v_author>
-                                <v_description>Initial draft</v_description>
-                        </version>
-                        <version date="2015-01-20T01:00:00" number="auto">
-                                <v_author>Ernest Hemingway</v_author>
-                                <v_description>Structure &amp; contents revision</v_description>
-                        </version>
-                        <version date="2015-01-21T01:00:00" number="auto">
-                                <v_author>Patricia Piolon</v_author>
-                                <v_description>Added some stuff</v_description>
-                        </version>
-                        <version date="2015-01-22T01:00:00" number="auto">
-                                <v_author>Patricia Piolon</v_author>
-                                <v_author>JRR Tolkien</v_author>
-                                <v_description>Revision</v_description>
-                        </version>
-                        <version date="2015-01-23T01:00:00" number="auto">
-                                <v_author>Patricia Piolon</v_author>
-                                <v_description>Revision</v_description>
-                        </version>
-                        <version date="2015-01-26T01:00:00" number="1.0">
-                                <v_author>Arthur Conan Doyle</v_author>
-                                <v_description>Finalizing</v_description>
-                        </version>
-                </version_history>
-                <xi:include href="snippets/company_info.xml"/>
-        </meta>
-        
-        <generate_index/>
-        
-        <section id="info">
-                <title>This is a generic document</title>
-                <section id="introduction">
-                        <title>This is a subsection</title>
-                        <p>In this document we describe anything that is not an offer, invoice or pentest.</p>
-                        <p>It is as generic as generic can be.</p>
-                </section>
-                <section id="other">
-                        <title>Some more info</title>
-                        <p>You can only use the most general of elements in this document (all the elements borrowed from html + monospace, code, section, appendix and title, basically).</p>
-                        <p>Only the company-related placeholders work!</p>
-                </section>
-        </section>
-        
-        
-        <section id="somethingelse">
-                <title>Anything else?</title>
-                <p>Mmmm no, that's it.</p>
-                
-                <table border="1"><tr><th>This is a table</th></tr>
-                        <tr><td>It contains bogus information.</td></tr></table>
-                
-                <section id="list">
-                        <title>List example</title>
-                        <p>This is a list:</p>
-                        <ul>
-                                <li>item 1 - see <a href="https://www.radicallyopensecurity.com">https://www.radicallyopensecurity.com</a>.</li>
-                                <li>item 2</li>
-                        </ul>
-                        <p>You get the idea</p>
-                </section>
-                <section id="bla">
-                        <title>other elements</title>
-                        <p>Command:</p>
-                        <pre>$ this is a pre (for command line entries)</pre>
-                        
-                        <p>Outcome:</p>
-                        <pre>This       is      where
+      </approver>
+    </collaborators>
+    <classification>Confidential</classification>
+    <version_history>
+      <version date="2015-01-19T01:00:00"
+               number="auto"
+      >
+        <v_author>Patricia Piolon</v_author>
+        <v_description>Initial draft</v_description>
+      </version>
+      <version date="2015-01-20T01:00:00"
+               number="auto"
+      >
+        <v_author>Ernest Hemingway</v_author>
+        <v_description>Structure &amp; contents revision</v_description>
+      </version>
+      <version date="2015-01-21T01:00:00"
+               number="auto"
+      >
+        <v_author>Patricia Piolon</v_author>
+        <v_description>Added some stuff</v_description>
+      </version>
+      <version date="2015-01-22T01:00:00"
+               number="auto"
+      >
+        <v_author>Patricia Piolon</v_author>
+        <v_author>JRR Tolkien</v_author>
+        <v_description>Revision</v_description>
+      </version>
+      <version date="2015-01-23T01:00:00"
+               number="auto"
+      >
+        <v_author>Patricia Piolon</v_author>
+        <v_description>Revision</v_description>
+      </version>
+      <version date="2015-01-26T01:00:00"
+               number="1.0"
+      >
+        <v_author>Arthur Conan Doyle</v_author>
+        <v_description>Finalizing</v_description>
+      </version>
+    </version_history>
+    <xi:include href="snippets/company_info.xml" />
+  </meta>
+
+  <generate_index />
+
+  <section id="info">
+    <title>This is a generic document</title>
+    <section id="introduction">
+      <title>This is a subsection</title>
+      <p>In this document we describe anything that is not an offer, invoice or pentest.</p>
+      <p>It is as generic as generic can be.</p>
+    </section>
+    <section id="other">
+      <title>Some more info</title>
+      <p>You can only use the most general of elements in this document (all the elements borrowed from html + monospace, code, section, appendix and title, basically).</p>
+      <p>Only the company-related placeholders work!</p>
+    </section>
+  </section>
+
+
+  <section id="somethingelse">
+    <title>Anything else?</title>
+    <p>Mmmm no, that's it.</p>
+
+    <table border="1"><tr><th>This is a table</th></tr>
+      <tr><td>It contains bogus information.</td></tr></table>
+
+    <section id="list">
+      <title>List example</title>
+      <p>This is a list:</p>
+      <ul>
+        <li>
+          item 1 - see
+          <a href="https://www.radicallyopensecurity.com">https://www.radicallyopensecurity.com</a>.
+        </li>
+        <li>item 2</li>
+      </ul>
+      <p>You get the idea</p>
+    </section>
+    <section id="bla">
+      <title>other elements</title>
+      <p>Command:</p>
+      <pre>$ this is a pre (for command line entries)</pre>
+
+      <p>Outcome:</p>
+      <pre>This       is      where
 you would write the
 output
 I
 guess.</pre>
-                        
-                        <p>Let's have a link pointing to <a href="#list"/> at this point.</p>
-                        
-                </section>
-                
-        </section>
-        <appendix id="testteam">
-                <title>Did we forget anything</title>
-                <p>Nope.</p>
-        </appendix>
+
+      <p>
+        Let's have a link pointing to
+        <a href="#list" />
+        at this point.
+      </p>
+
+    </section>
+
+  </section>
+  <appendix id="testteam">
+    <title>Did we forget anything</title>
+    <p>Nope.</p>
+  </appendix>
 </generic_document>

--- a/doc/examples/exampleinvoice.xml
+++ b/doc/examples/exampleinvoice.xml
@@ -1,30 +1,34 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<invoice xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink"
-    xmlns:fo="http://www.w3.org/1999/XSL/Format" xsi:noNamespaceSchemaLocation="../dtd/invoice.xsd"
-    invoice_no="00/000" denomination="dollar">
-    <meta>
-        <xi:include href="snippets/company_info.xml"/>
-        <xi:include href="client_info.xml"/>
-    </meta>
-    <servicesdelivered>
-        <service>
-            <description>10-day penetration test Sitting Duck</description>
-            <fee vat="yes">7000</fee>
-        </service>
-        <service>
-            <description>Something else</description>
-            <fee vat="yes">2000</fee>
-        </service>
-    </servicesdelivered>
-    <additionalcosts>
-        <cost>
-            <description>An additional cost without vat</description>
-            <fee vat="no">1000</fee>
-        </cost>
-        <cost>
-            <description>An additional cost with vat</description>
-            <fee vat="yes">1000</fee>
-        </cost>
-    </additionalcosts>
+<?xml version="1.0" encoding="utf-8"?>
+<invoice xmlns:fo="http://www.w3.org/1999/XSL/Format"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         denomination="usd"
+         invoice_no="00/000"
+         xsi:noNamespaceSchemaLocation="../dtd/invoice.xsd"
+>
+  <meta>
+    <xi:include href="snippets/company_info.xml" />
+    <xi:include href="client_info.xml" />
+  </meta>
+  <servicesdelivered>
+    <service>
+      <description>10-day penetration test Sitting Duck</description>
+      <fee vat="yes">7000</fee>
+    </service>
+    <service>
+      <description>Something else</description>
+      <fee vat="yes">2000</fee>
+    </service>
+  </servicesdelivered>
+  <additionalcosts>
+    <cost>
+      <description>An additional cost without vat</description>
+      <fee vat="no">1000</fee>
+    </cost>
+    <cost>
+      <description>An additional cost with vat</description>
+      <fee vat="yes">1000</fee>
+    </cost>
+  </additionalcosts>
 </invoice>

--- a/doc/examples/exampleofferte.xml
+++ b/doc/examples/exampleofferte.xml
@@ -1,80 +1,83 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<offerte xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<?xml version="1.0" encoding="utf-8"?>
+<offerte xmlns:fo="http://www.w3.org/1999/XSL/Format"
          xmlns:xi="http://www.w3.org/2001/XInclude"
          xmlns:xlink="http://www.w3.org/1999/xlink"
-         xmlns:fo="http://www.w3.org/1999/XSL/Format"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xml:lang="en"
          xsi:noNamespaceSchemaLocation="../dtd/offerte.xsd"
-         xml:lang="en"><!--document meta information; to be filled in by the offerte writer-->
-   <meta>
-      <title>quote</title>
-      <offered_service_long>penetration testing services</offered_service_long>
-      <!--if there is a shorter way of saying the same thing, you can type it here (it makes for more dynamic offerte text). If not, just repeat the long name.-->
-      <offered_service_short>penetration test</offered_service_short>
-      <xi:include href="snippets/company_info.xml"/>
-      <targets><!--one target element per target-->
-         <target>target1.sittingduck.com</target>
-         <target>target2.sittingduck.com</target>
-         <target>FishInABarrel App</target>
-      </targets>
-      <permission_parties>
-         <xi:include href="client_info.xml"/>
-         <party>
-            <full_name>HotshotDevs Inc.</full_name>
-            <short_name>HotshotDevs</short_name>
-            <!--short party name; if no short name: same as long name-->
-            <waiver_rep>Hotshot Dev Lawyer</waiver_rep>
-            <address>Silicon Valley St. 50</address>
-            <postal_code>10000</postal_code>
-            <city>San Francisco</city>
-            <country>US</country>
-         </party>
-      </permission_parties>
-      <activityinfo>
-         <duration>10</duration>
-         <!--duration of pentest, in working days-->
-         <persondays>20</persondays>
-         <planning>
-            <start>2018-01-01</start>
-            <end>2018-02-02</end>
-         </planning>
-         <!--date or date range in text, e.g. May 18th until May 25th, 2015-->
-         <report_due>2018-03-03</report_due>
-         <nature>time-boxed</nature>
-         <type>crystal-box</type>
-         <!--please choose one of the following: black-box, grey-box, crystal-box-->
-         <fee denomination="eur">1000000</fee>
-         <!--(euro|dollar)-->
-         <target_application>FishInABarrel</target_application>
-         <!--name of application/service to be tested (if any; if none, DELETE target_application element)-->
-      </activityinfo>
-      <version_history><!--needed for date on frontpage and in signature boxes; it is possible to add a new <version> after each review; in that case, make sure to update the date/time-->
-         <version number="auto" date="2016-07-08T10:00:00"><!--actual date-time here; you can leave the number attribute alone-->
-            <v_author>ROS Writer</v_author>
-            <!--name of the author here; for internal use only-->
-            <v_description>Initial draft</v_description>
-            <!--for internal use only-->
-         </version>
-      </version_history>
-   </meta>
-   <!--Introduction and Scope-->
-   <xi:include href="snippets/offerte/en/introandscope.xml"/>
-   <!--Project overview section-->
-   <xi:include href="snippets/offerte/en/projectoverview.xml"/>
-   <!--Prerequisites section-->
-   <xi:include href="snippets/offerte/en/prerequisites.xml"/>
-   <!--Disclaimer section-->
-   <xi:include href="snippets/offerte/en/disclaimer.xml"/>
-   <!--Methodology section-->
-   <xi:include href="snippets/offerte/en/methodology.xml"/>
-   <xi:include href="snippets/offerte/en/teamandreporting.xml"/>
-   <!--Planning and payment section-->
-   <xi:include href="snippets/offerte/en/planningandpayment.xml"/>
-   <!--About Us section-->
-   <xi:include href="snippets/offerte/en/aboutus.xml"/>
-   <!--Work condition section-->
-   <xi:include href="snippets/offerte/en/conditions.xml"/>
-   <!--General terms and conditions section-->
-   <xi:include href="snippets/offerte/en/generaltermsandconditions.xml"/>
-   <!--Waivers-->
-   <xi:include href="snippets/offerte/en/waiver.xml"/>
+><!--document meta information; to be filled in by the offerte writer-->
+  <meta>
+    <title>quote</title>
+    <offered_service_long>penetration testing services</offered_service_long>
+    <!--if there is a shorter way of saying the same thing, you can type it here (it makes for more dynamic offerte text). If not, just repeat the long name.-->
+    <offered_service_short>penetration test</offered_service_short>
+    <xi:include href="snippets/company_info.xml" />
+    <targets><!--one target element per target-->
+      <target>target1.sittingduck.com</target>
+      <target>target2.sittingduck.com</target>
+      <target>FishInABarrel App</target>
+    </targets>
+    <permission_parties>
+      <xi:include href="client_info.xml" />
+      <party>
+        <full_name>HotshotDevs Inc.</full_name>
+        <short_name>HotshotDevs</short_name>
+        <!--short party name; if no short name: same as long name-->
+        <waiver_rep>Hotshot Dev Lawyer</waiver_rep>
+        <address>Silicon Valley St. 50</address>
+        <postal_code>10000</postal_code>
+        <city>San Francisco</city>
+        <country>US</country>
+      </party>
+    </permission_parties>
+    <activityinfo>
+      <duration>10</duration>
+      <!--duration of pentest, in working days-->
+      <persondays>20</persondays>
+      <planning>
+        <start>2018-01-01</start>
+        <end>2018-02-02</end>
+      </planning>
+      <!--date or date range in text, e.g. May 18th until May 25th, 2015-->
+      <report_due>2018-03-03</report_due>
+      <nature>time-boxed</nature>
+      <type>crystal-box</type>
+      <!--please choose one of the following: black-box, grey-box, crystal-box-->
+      <fee denomination="eur">1000000</fee>
+      <!--(euro|dollar)-->
+      <target_application>FishInABarrel</target_application>
+      <!--name of application/service to be tested (if any; if none, DELETE target_application element)-->
+    </activityinfo>
+    <version_history><!--needed for date on frontpage and in signature boxes; it is possible to add a new <version> after each review; in that case, make sure to update the date/time-->
+      <version date="2016-07-08T10:00:00"
+               number="auto"
+      ><!--actual date-time here; you can leave the number attribute alone-->
+        <v_author>ROS Writer</v_author>
+        <!--name of the author here; for internal use only-->
+        <v_description>Initial draft</v_description>
+        <!--for internal use only-->
+      </version>
+    </version_history>
+  </meta>
+  <!--Introduction and Scope-->
+  <xi:include href="snippets/offerte/en/introandscope.xml" />
+  <!--Project overview section-->
+  <xi:include href="snippets/offerte/en/projectoverview.xml" />
+  <!--Prerequisites section-->
+  <xi:include href="snippets/offerte/en/prerequisites.xml" />
+  <!--Disclaimer section-->
+  <xi:include href="snippets/offerte/en/disclaimer.xml" />
+  <!--Methodology section-->
+  <xi:include href="snippets/offerte/en/methodology.xml" />
+  <xi:include href="snippets/offerte/en/teamandreporting.xml" />
+  <!--Planning and payment section-->
+  <xi:include href="snippets/offerte/en/planningandpayment.xml" />
+  <!--About Us section-->
+  <xi:include href="snippets/offerte/en/aboutus.xml" />
+  <!--Work condition section-->
+  <xi:include href="snippets/offerte/en/conditions.xml" />
+  <!--General terms and conditions section-->
+  <xi:include href="snippets/offerte/en/generaltermsandconditions.xml" />
+  <!--Waivers-->
+  <xi:include href="snippets/offerte/en/waiver.xml" />
 </offerte>

--- a/doc/examples/examplequickscope.xml
+++ b/doc/examples/examplequickscope.xml
@@ -1,64 +1,64 @@
-<?xml version="1.0" encoding="UTF-8"?>
-
+<?xml version="1.0" encoding="utf-8"?>
 <quickscope xmlns:xi="http://www.w3.org/2001/XInclude"
-    xmlns:xml="http://www.w3.org/XML/1998/namespace"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="../dtd/quickscope.xsd">
-    
-    <!-- COMPANY INFO -->
-    <xi:include href="client_info.xml"/>
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:noNamespaceSchemaLocation="../dtd/quickscope.xsd"
+>
 
-    <!-- SERVICE INFO -->
-    <meta>
-        <!-- Language the offer should be in (en|nl) -->
-        <offer_language>en</offer_language>
-        <!-- Offer type (pentest|basic-scan|load-test|other) -->
-        <offer_type>pentest</offer_type>
-        <!-- Required service -->
-        <!-- Note: is only used when type is 'other', if offer_type is a specific type, service name will be taken from the localisation strings -->
+  <!-- COMPANY INFO -->
+  <xi:include href="client_info.xml" />
+
+  <!-- SERVICE INFO -->
+  <meta>
+    <!-- Language the offer should be in (en|nl) -->
+    <offer_language>en</offer_language>
+    <!-- Offer type (pentest|basic-scan|load-test|other) -->
+    <offer_type>pentest</offer_type>
+    <!-- Required service -->
+    <!-- Note: is only used when type is 'other', if offer_type is a specific type, service name will be taken from the localisation strings -->
     <requested_service>penetration testing services</requested_service>
-    
-    </meta>
-    <!-- Do we need permission from third parties? Insert as many <third_party> elements as needed under this comment -->
-    <third_party>
-        <full_name>Third Party BV</full_name>
-        <short_name>Third Party</short_name>
-        <!-- Name of the person who will need to sign the waiver for this vendor -->
-        <waiver_rep>TP Waiver Rep</waiver_rep>
-        <address>TP Street 123</address>
-        <postal_code>0001 XX</postal_code>
-        <city>TP City</city>
-        <country>TP Country</country>
-    </third_party>
 
-    <activityinfo>
-        <!-- Which targets will need to be tested? 
+  </meta>
+  <!-- Do we need permission from third parties? Insert as many <third_party> elements as needed under this comment -->
+  <third_party>
+    <full_name>Third Party BV</full_name>
+    <short_name>Third Party</short_name>
+    <!-- Name of the person who will need to sign the waiver for this vendor -->
+    <waiver_rep>TP Waiver Rep</waiver_rep>
+    <address>TP Street 123</address>
+    <postal_code>0001 XX</postal_code>
+    <city>TP City</city>
+    <country>TP Country</country>
+  </third_party>
+
+  <activityinfo>
+    <!-- Which targets will need to be tested? 
         (one <target> element for each piece of software/service/server address/location...), delete/add as necessary -->
-        <targets>
-            <target>target1.target.com</target>
-            <target>target2.target.com</target>
-        </targets>
-        <!-- How long would you like the test to be? (in days) -->
-        <days>6</days>
-        <!-- How many persondays (if you don't know, try days * number of assigned pentesters) -->
-        <persondays>12</persondays>
-        <!-- Service execution (Use one of the following values: time-boxed, subscription) -->
-        <nature>time-boxed</nature>
-        <!-- Testing type (Use one of the following values: crystal-box, black-box, grey-box) -->
-        <type>crystal-box</type>
-        <!-- Test planning (when would you like the test to be executed -->
-        <!-- Ideally something specific like 'December 7th - December 12th, 2015', but another description 'Beginning of December' is fine as well -->
-        <!-- do not start with a capital letter -->
-        <planning>TBD</planning>
-        <!-- Pentest report delivery date (please allow at least 1 week between the end of the pentest and the report delivery date) -->
-        <delivery>TBD</delivery>
-        <!-- Do you need/want a code audit? (possible values: yes/no), only for pentest -->
-        <codeaudit perform="yes"/>
-        <!-- Is there an application that needs to be tested? Add an <application_name> element below. -->
-        <application_name>AppToTest</application_name>
-        
-        <!-- rate (to be filled in by ROS ;) -->
-        <rate>40000</rate>
+    <targets>
+      <target>target1.target.com</target>
+      <target>target2.target.com</target>
+    </targets>
+    <!-- How many persondays (if you don't know, try days * number of assigned pentesters) -->
+    <persondays>12</persondays>
+    <!-- Service execution (Use one of the following values: time-boxed, subscription) -->
+    <nature>time-boxed</nature>
+    <!-- Testing type (Use one of the following values: crystal-box, black-box, grey-box) -->
+    <type>crystal-box</type>
+    <!-- Test planning (when would you like the test to be executed -->
+    <!-- Ideally something specific like 'December 7th - December 12th, 2015', but another description 'Beginning of December' is fine as well -->
+    <!-- do not start with a capital letter -->
+    <planning>
+      <start>TBD</start>
+      <end>TBD</end>
+    </planning>
+    <!-- Pentest report delivery date (please allow at least 1 week between the end of the pentest and the report delivery date) -->
+    <delivery>TBD</delivery>
+    <!-- Do you need/want a code audit? (possible values: yes/no), only for pentest -->
+    <codeaudit perform="yes" />
+    <!-- Is there an application that needs to be tested? Add an <application_name> element below. -->
+    <application_name>AppToTest</application_name>
 
-    </activityinfo>
+    <!-- rate (to be filled in by ROS ;) -->
+    <rate>40000</rate>
+
+  </activityinfo>
 </quickscope>

--- a/doc/examples/examplereport.xml
+++ b/doc/examples/examplereport.xml
@@ -1,202 +1,237 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <pentest_report xmlns:xi="http://www.w3.org/2001/XInclude"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" findingCode="SID"
-        xsi:noNamespaceSchemaLocation="../dtd/pentestreport.xsd">
-        <meta>
-                <title>Penetration Test Report</title>
-                <targets>
-                        <target>fishinabarrel.sittingduck.com</target>
-                </targets>
-                <activityinfo>
-                        <duration>4</duration>
-                        <persondays>4</persondays>
-                        <planning>
-                                <start>TBD</start>
-                                <end>TBD</end>
-                        </planning>
-                        <report_due>bla</report_due>
-                        <nature>something</nature>
-                        <type>black-box</type>
-                </activityinfo>
-                <permission_parties>
-                        <xi:include href="client_info.xml"/>
-                </permission_parties>
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                findingCode="SID"
+                xsi:noNamespaceSchemaLocation="../dtd/pentestreport.xsd"
+>
+  <meta>
+    <title>Penetration Test Report</title>
+    <targets>
+      <target>fishinabarrel.sittingduck.com</target>
+    </targets>
+    <activityinfo>
+      <persondays>4</persondays>
+      <planning>
+        <start>TBD</start>
+        <end>TBD</end>
+      </planning>
+      <report_due>bla</report_due>
+      <nature>something</nature>
+      <type>black-box</type>
+    </activityinfo>
+    <permission_parties>
+      <xi:include href="client_info.xml" />
+    </permission_parties>
 
-                <collaborators>
-                        <reviewers>
-                                <reviewer>Melanie Rieback</reviewer>
-                        </reviewers>
-                        <approver>
-                                <name>Melanie Rieback</name>
-                                <bio>Melanie Rieback is a former Asst. Prof. of Computer Science from the VU,
+    <collaborators>
+      <reviewers>
+        <reviewer>Melanie Rieback</reviewer>
+      </reviewers>
+      <approver>
+        <name>Melanie Rieback</name>
+        <bio>Melanie Rieback is a former Asst. Prof. of Computer Science from the VU,
 who is also the co-founder/CEO of Radically Open Security.</bio>
-                        </approver>
-                        <pentesters>
-                                <pentester>
-                                        <name>Melanie Rieback</name>
-                                        <bio>Melanie Rieback is a former Asst. Prof. of Computer Science from the VU,
+      </approver>
+      <pentesters>
+        <pentester>
+          <name>Melanie Rieback</name>
+          <bio>Melanie Rieback is a former Asst. Prof. of Computer Science from the VU,
                                                 who is also the co-founder/CEO of Radically Open Security.</bio>
-                                </pentester>
-                                <pentester>
-                                        <name>Aristotle</name>
-                                        <bio>Greek philosopher and scientist born in the Macedonian city of Stagira, Chalkidice, on the northern periphery of Classical Greece.</bio>
-                                </pentester>
-                                <pentester>
-                                        <name>George Boole</name>
-                                        <bio>English mathematician, philosopher and logician. Works in the fields of differential equations and algebraic logic, and is now best known as the author of The Laws of Thought.</bio>
-                                </pentester>
-                                <pentester>
-                                        <name>William of Ockham</name>
-                                        <bio>English Franciscan friar and scholastic philosopher and theologian. Considered to be one of the major figures of medieval thought. At the centre of some major intellectual and political controversies.</bio>
-                                </pentester>
-                                <pentester>
-                                        <name>Ludwig Josef Johann Wittgenstein</name>
-                                        <bio>Austrian-British philosopher who works primarily in logic, the philosophy of mathematics, the philosophy of mind, and the philosophy of language.</bio>
-                                </pentester>
-                        </pentesters>
-                </collaborators>
-                <classification>Confidential</classification>
-                <version_history>
-                        <version date="2015-01-19T01:00:00" number="auto">
-                                <v_author>Patricia Piolon</v_author>
-                                <v_description>Initial draft</v_description>
-                        </version>
-                        <version date="2015-01-20T01:00:00" number="auto">
-                                <v_author>Ernest Hemingway</v_author>
-                                <v_description>Structure &amp; contents revision</v_description>
-                        </version>
-                        <version date="2015-01-21T01:00:00" number="auto">
-                                <v_author>Patricia Piolon</v_author>
-                                <v_description>Added threat levels and recommendations</v_description>
-                        </version>
-                        <version date="2015-01-22T01:00:00" number="auto">
-                                <v_author>Patricia Piolon</v_author>
-                                <v_author>JRR Tolkien</v_author>
-                                <v_description>Revision</v_description>
-                        </version>
-                        <version date="2015-01-23T01:00:00" number="auto">
-                                <v_author>Patricia Piolon</v_author>
-                                <v_description>Revision</v_description>
-                        </version>
-                        <version date="2015-01-26T01:00:00" number="1.0">
-                                <v_author>Arthur Conan Doyle</v_author>
-                                <v_description>Finalizing</v_description>
-                        </version>
-                </version_history>
-                <xi:include href="snippets/company_info.xml"/>
-        </meta>
+        </pentester>
+        <pentester>
+          <name>Aristotle</name>
+          <bio>Greek philosopher and scientist born in the Macedonian city of Stagira, Chalkidice, on the northern periphery of Classical Greece.</bio>
+        </pentester>
+        <pentester>
+          <name>George Boole</name>
+          <bio>English mathematician, philosopher and logician. Works in the fields of differential equations and algebraic logic, and is now best known as the author of The Laws of Thought.</bio>
+        </pentester>
+        <pentester>
+          <name>William of Ockham</name>
+          <bio>English Franciscan friar and scholastic philosopher and theologian. Considered to be one of the major figures of medieval thought. At the centre of some major intellectual and political controversies.</bio>
+        </pentester>
+        <pentester>
+          <name>Ludwig Josef Johann Wittgenstein</name>
+          <bio>Austrian-British philosopher who works primarily in logic, the philosophy of mathematics, the philosophy of mind, and the philosophy of language.</bio>
+        </pentester>
+      </pentesters>
+    </collaborators>
+    <classification>Confidential</classification>
+    <version_history>
+      <version date="2015-01-19T01:00:00"
+               number="auto"
+      >
+        <v_author>Patricia Piolon</v_author>
+        <v_description>Initial draft</v_description>
+      </version>
+      <version date="2015-01-20T01:00:00"
+               number="auto"
+      >
+        <v_author>Ernest Hemingway</v_author>
+        <v_description>Structure &amp; contents revision</v_description>
+      </version>
+      <version date="2015-01-21T01:00:00"
+               number="auto"
+      >
+        <v_author>Patricia Piolon</v_author>
+        <v_description>Added threat levels and recommendations</v_description>
+      </version>
+      <version date="2015-01-22T01:00:00"
+               number="auto"
+      >
+        <v_author>Patricia Piolon</v_author>
+        <v_author>JRR Tolkien</v_author>
+        <v_description>Revision</v_description>
+      </version>
+      <version date="2015-01-23T01:00:00"
+               number="auto"
+      >
+        <v_author>Patricia Piolon</v_author>
+        <v_description>Revision</v_description>
+      </version>
+      <version date="2015-01-26T01:00:00"
+               number="1.0"
+      >
+        <v_author>Arthur Conan Doyle</v_author>
+        <v_description>Finalizing</v_description>
+      </version>
+    </version_history>
+    <xi:include href="snippets/company_info.xml" />
+  </meta>
 
-        <generate_index/>
+  <generate_index />
 
-        <section id="executiveSummary">
-                <title>Executive Summary</title>
-                <section id="introduction">
-                        <title>Introduction</title>
-                        <p>Sitting Duck B.V. (“Sitting Duck”) has assigned the task of performing a
+  <section id="executiveSummary">
+    <title>Executive Summary</title>
+    <section id="introduction">
+      <title>Introduction</title>
+      <p>Sitting Duck B.V. (“Sitting Duck”) has assigned the task of performing a
                                 Penetration Test of the FishInABarrel Web Application to Radically
                                 Open Security BV (hereafter “ROS”). Sitting Duck has made this
                                 request to better evaluate the security of the application and to
                                 identify application level vulnerabilities in order to see whether
                                 the FishInABarrel Web Application is ready, security-wise, for
                                 production deployment.</p>
-                        <p>This report contains our findings as well as detailed explanations of
+      <p>This report contains our findings as well as detailed explanations of
                                 exactly how ROS performed the penetration test.</p>
-                </section>
-                <section id="scope">
-                        <title>Scope of work</title>
-                        <p>The scope of the Sitting Duck penetration test was limited to the
+    </section>
+    <section id="scope">
+      <title>Scope of work</title>
+      <p>The scope of the Sitting Duck penetration test was limited to the
                                 following target:</p>
-                        <generate_targets/>
-                        <p>The penetration test was carried out from a black box perspective: no
+      <generate_targets />
+      <p>The penetration test was carried out from a black box perspective: no
                                 information regarding the system(s) tested was provided by Sitting
                                 Duck or FishInABarrel, although FishInABarrel did provide ROS with
                                 two test user accounts.</p>
-                </section>
-                <section id="objectives">
-                        <title>Project objectives</title>
-                        <p>The objective of the security assessment is to gain insight into the
+    </section>
+    <section id="objectives">
+      <title>Project objectives</title>
+      <p>The objective of the security assessment is to gain insight into the
                                 security of the host and the FishInABarrel Web Application.</p>
-                </section>
-                <section id="timeline">
-                        <title>Timeline</title>
-                        <p>The FishInABarrel Security Audit took place between January 14 and
+    </section>
+    <section id="timeline">
+      <title>Timeline</title>
+      <p>The FishInABarrel Security Audit took place between January 14 and
                                 January 16, 2015.</p>
-                </section>
-                <section id="results">
-                        <title>Results in a Nutshell</title>
-                        <p>During this pentest, we found quite a number of different security
+    </section>
+    <section id="results">
+      <title>Results in a Nutshell</title>
+      <p>During this pentest, we found quite a number of different security
                                 problems – Cross-site Scripting (XSS) vulnerabilities, both stored
                                 and reflected, Cross-site Request Forgery (CSRF) vulnerabilities,
                                 information disclosures (multiple instances), and lack of brute
                                 force protection.</p>
-                </section>
-                <section id="findingSummary">
-                        <title>Summary of Findings</title>
-                        <generate_findings/>
-                        <!-- generated from Findings section -->
-                </section>
-                <section id="recommendationSummary">
-                        <title>Summary of Recommendations</title>
-                        <generate_recommendations/>
-                        <!-- generated from Findings section -->
-                </section>
-                <section id="dataSummary">
-                        <title>Charts</title>
-                        <section id="threatlevelpie">
-                                <title>Findings by Threat Level</title>
-                                <generate_piechart pieAttr="threatLevel" pieElem="finding"
-                                        pieHeight="200"/>
-                        </section>
-                        <section id="typepie">
-                                <title>Findings by Type</title>
-                                <generate_piechart pieAttr="type" pieElem="finding" pieHeight="200"
-                                />
-                        </section>
+    </section>
+    <section id="findingSummary">
+      <title>Summary of Findings</title>
+      <generate_findings />
+      <!-- generated from Findings section -->
+    </section>
+    <section id="recommendationSummary">
+      <title>Summary of Recommendations</title>
+      <generate_recommendations />
+      <!-- generated from Findings section -->
+    </section>
+    <section id="dataSummary">
+      <title>Charts</title>
+      <section id="threatlevelpie">
+        <title>Findings by Threat Level</title>
+        <generate_piechart pieAttr="threatLevel"
+                           pieElem="finding"
+        />
+      </section>
+      <section id="typepie">
+        <title>Findings by Type</title>
+        <generate_piechart pieAttr="type"
+                           pieElem="finding"
+        />
+      </section>
 
-                        <!-- generated from Findings section -->
-                </section>
-        </section>
+      <!-- generated from Findings section -->
+    </section>
+  </section>
 
-        <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-                href="snippets/report/methodology.xml"/>
+  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+              href="snippets/report/methodology.xml"
+  />
 
-        <section id="recon">
-                <title>Reconnaissance and Fingerprinting</title>
-                <p>Through automated scans we were able to gain the following information about the
+  <section id="recon">
+    <title>Reconnaissance and Fingerprinting</title>
+    <p>Through automated scans we were able to gain the following information about the
                         software and infrastructure. Detailed scan output can be found in the
                         sections below.</p>
 
-                <table border="1">
-                        <tr>
-                                <th>Fingerprinted Information</th>
-                        </tr>
-                        <tr>
-                                <td>Windows XP<br/>Microsoft IIS 6.0<br/>PHP 5.4.29<br/>jQuery
-                                        1.7.2<br/>Mailserver XYZ<br/>FTPserver ABC</td>
-                        </tr>
-                </table>
+    <table border="1">
+      <tr>
+        <th>Fingerprinted Information</th>
+      </tr>
+      <tr>
+        <td>
+          Windows XP<br />
+          Microsoft IIS 6.0<br />
+          PHP 5.4.29<br />
+          jQuery
+          1.7.2<br />
+          Mailserver XYZ<br />
+          FTPserver ABC
+        </td>
+      </tr>
+    </table>
 
-                <section id="scans">
-                        <title>Automated Scans</title>
-                        <p>As part of our active reconnaissance we used the following automated
+    <section id="scans">
+      <title>Automated Scans</title>
+      <p>As part of our active reconnaissance we used the following automated
                                 scans:</p>
-                        <ul>
-                                <li>nmap – <a href="https://nmap.org">https://nmap.org</a></li>
-                                <li>skipfish - <a href="https://code.google.com/p/skipfish/">https://code.google.com/p/skipfish/</a></li>
-                                <li>sqlmap – <a href="http://sqlmap.org">http://sqlmap.org</a></li>
-                                <li>Wapiti – <a href="http://wapiti.sourceforge.net">http://wapiti.sourceforge.net</a></li>
-                        </ul>
-                        <p>Of these, only the output of nmap turned out to be useful; consequently
+      <ul>
+        <li>
+          nmap –
+          <a href="https://nmap.org">https://nmap.org</a>
+        </li>
+        <li>
+          skipfish -
+          <a href="https://code.google.com/p/skipfish/">https://code.google.com/p/skipfish/</a>
+        </li>
+        <li>
+          sqlmap –
+          <a href="http://sqlmap.org">http://sqlmap.org</a>
+        </li>
+        <li>
+          Wapiti –
+          <a href="http://wapiti.sourceforge.net">http://wapiti.sourceforge.net</a>
+        </li>
+      </ul>
+      <p>Of these, only the output of nmap turned out to be useful; consequently
                                 only nmap and output will be discussed in this section.</p>
-                </section>
-                <section id="nmap">
-                        <title>nmap</title>
-                        <p>Command:</p>
-                        <pre>$ nmap -vvvv -oA fishinabarrel.sittingduck.com_complete -sV -sC -A -p1-65535 -T5
+    </section>
+    <section id="nmap">
+      <title>nmap</title>
+      <p>Command:</p>
+      <pre>$ nmap -vvvv -oA fishinabarrel.sittingduck.com_complete -sV -sC -A -p1-65535 -T5
 fishinabarrel.sittingduck.com</pre>
 
-                        <p>Outcome:</p>
-                        <pre>Nmap scan report for fishinabarrel.sittingduck.com (10.10.10.1)
+      <p>Outcome:</p>
+      <pre>Nmap scan report for fishinabarrel.sittingduck.com (10.10.10.1)
 Starting Nmap 4.11 ( http://www.insecure.org/nmap/ ) at 2013-11-11 15:43 EST
 Initiating ARP Ping Scan against 10.10.10.1 [1 port] at 15:43
 The ARP Ping Scan took 0.01s to scan 1 total hosts.
@@ -224,126 +259,154 @@ PORT     STATE SERVICE
 Nmap finished: 1 IP address (1 host up) scanned in 0.485 seconds
 Raw packets sent: 1681 (73.962KB) | Rcvd: 1681 (77.322KB)</pre>
 
-                        <p>The scan revealed a very large number of open services on this machine,
-                                which greatly increases the attack surface; see <a href="#f2"/> for
-                                more information on the security risk.</p>
+      <p>
+        The scan revealed a very large number of open services on this machine,
+        which greatly increases the attack surface; see
+        <a href="#f2" />
+        for
+        more information on the security risk.
+      </p>
 
-                </section>
+    </section>
 
-        </section>
+  </section>
 
-        <section id="findings">
-                <title>Findings</title>
+  <section id="findings">
+    <title>Findings</title>
 
-                <p>We have identified the following issues:</p>
+    <p>We have identified the following issues:</p>
 
-                <finding id="f1" threatLevel="Moderate" type="Information Leak">
-                        <title>PHPInfo Disclosure</title>
-                        <description>
-                                <p>The phpinfo() function of the PHP language is readable, resulting
+    <finding id="f1"
+             number="1"
+             threatLevel="Moderate"
+             type="Information Leak"
+    >
+      <title>PHPInfo Disclosure</title>
+      <description>
+        <p>The phpinfo() function of the PHP language is readable, resulting
                                         in a listing of all the runtime information of the
                                         environment, thus disclosing potentially valuable
                                         information to attackers.</p>
-                        </description>
-                        <technicaldescription>
-                                <p>This is where the good stuff goes. We give a detailed technical
+      </description>
+      <technicaldescription>
+        <p>This is where the good stuff goes. We give a detailed technical
                                         description of the problem.</p>
-                                <p>Illustrative picture of an evil hacker pondering dark deeds:</p>
-                                <img height="10" src="../graphics/screenshot.jpg"/>
-                        </technicaldescription>
-                        <impact>
-                                <p>This is where we explain how the sh*t is hitting the fan,
+        <p>Illustrative picture of an evil hacker pondering dark deeds:</p>
+        <img height="10"
+             src="../graphics/screenshot.jpg"
+        />
+      </technicaldescription>
+      <impact>
+        <p>This is where we explain how the sh*t is hitting the fan,
                                         exactly.</p>
-                        </impact>
-                        <recommendation>
-                                <p>Here is where we write some tips to solve the problem.</p>
-                        </recommendation>
-                </finding>
+      </impact>
+      <recommendation>
+        <p>Here is where we write some tips to solve the problem.</p>
+      </recommendation>
+    </finding>
 
-                <finding id="f2" threatLevel="High" type="XSS">
-                        <title>A terrible XSS issue</title>
-                        <description>
-                                <p>A general description of the problem.</p>
-                        </description>
-                        <technicaldescription>
-                                <p>This is we go into great detail about the vulnerability.</p>
-                        </technicaldescription>
-                        <impact>
-                                <p>This is where we explain why this vulnerability is a problem.</p>
-                        </impact>
-                        <recommendation>
-                                <p>This is where we solve everything and the sun starts shining
+    <finding id="f2"
+             number="2"
+             threatLevel="High"
+             type="XSS"
+    >
+      <title>A terrible XSS issue</title>
+      <description>
+        <p>A general description of the problem.</p>
+      </description>
+      <technicaldescription>
+        <p>This is we go into great detail about the vulnerability.</p>
+      </technicaldescription>
+      <impact>
+        <p>This is where we explain why this vulnerability is a problem.</p>
+      </impact>
+      <recommendation>
+        <p>This is where we solve everything and the sun starts shining
                                         again.</p>
-                        </recommendation>
-                </finding>
+      </recommendation>
+    </finding>
 
-                <finding id="f3" threatLevel="Low" type="XSS">
-                        <title>A not quite so terrible XSS issue</title>
-                        <description>
-                                <p>A description of the problem.</p>
-                        </description>
-                        <technicaldescription>
-                                <p>Vulnerability described in detail.</p>
-                        </technicaldescription>
-                        <impact>
-                                <p>Impact on security.</p>
-                        </impact>
-                        <recommendation>
-                                <p>A ready solution.</p>
-                        </recommendation>
-                </finding>
-        </section>
+    <finding id="f3"
+             number="3"
+             threatLevel="Low"
+             type="XSS"
+    >
+      <title>A not quite so terrible XSS issue</title>
+      <description>
+        <p>A description of the problem.</p>
+      </description>
+      <technicaldescription>
+        <p>Vulnerability described in detail.</p>
+      </technicaldescription>
+      <impact>
+        <p>Impact on security.</p>
+      </impact>
+      <recommendation>
+        <p>A ready solution.</p>
+      </recommendation>
+    </finding>
+  </section>
 
-        <section id="nonFindings">
-                <title>Non-Findings</title>
-                <p>In this section we list some of the things that were tried but turned out to be
+  <section id="nonFindings">
+    <title>Non-Findings</title>
+    <p>In this section we list some of the things that were tried but turned out to be
                         dead ends.</p>
 
-                <non-finding id="ftp">
-                        <title>FTP</title>
-                        <p>The server was running FTPserver ABC, the most recent version of this
+    <non-finding id="ftp"
+                 number="1"
+    >
+      <title>FTP</title>
+      <p>The server was running FTPserver ABC, the most recent version of this
                                 particular piece of software. Anonymous login was turned off and no
                                 relevant vulnerabilities or exploits were found.</p>
-                </non-finding>
-                <non-finding id="mail">
-                        <title>Mail Server</title>
-                        <p>The server was running Mailserver XYZ, the most recent version of this
+    </non-finding>
+    <non-finding id="mail"
+                 number="2"
+    >
+      <title>Mail Server</title>
+      <p>The server was running Mailserver XYZ, the most recent version of this
                                 particular piece of software. No relevant vulnerabilities or
                                 exploits were found.</p>
-                </non-finding>
-                <non-finding id="sqlInjection">
-                        <title>SQL Code Injection</title>
-                        <p>The following parameters are not vulnerable to SQL injection.</p>
-                        <p>All parameters have been checked manually.</p>
-                        <pre>-file1.php
+    </non-finding>
+    <non-finding id="sqlInjection"
+                 number="3"
+    >
+      <title>SQL Code Injection</title>
+      <p>The following parameters are not vulnerable to SQL injection.</p>
+      <p>All parameters have been checked manually.</p>
+      <pre>-file1.php
 -file2.php
 -file3.php
 </pre>
-                </non-finding>
-                <non-finding id="heartbleed">
-                        <title>Heartbleed</title>
-                        <p>System was not vulnerable to heartbleed.</p>
-                </non-finding>
-                <non-finding id="sp2">
-                        <title>Windows XP</title>
-                        <p>The host is running Windows XP. As we all know, Windows XP is
+    </non-finding>
+    <non-finding id="heartbleed"
+                 number="4"
+    >
+      <title>Heartbleed</title>
+      <p>System was not vulnerable to heartbleed.</p>
+    </non-finding>
+    <non-finding id="sp2"
+                 number="5"
+    >
+      <title>Windows XP</title>
+      <p>The host is running Windows XP. As we all know, Windows XP is
                                 bulletproof.</p>
-                </non-finding>
-        </section>
-        <section id="conclusion">
-                <title>Conclusion</title>
-                <p>In the course of this penetration test, we have demonstrated that the
+    </non-finding>
+  </section>
+  <section id="conclusion">
+    <title>Conclusion</title>
+    <p>In the course of this penetration test, we have demonstrated that the
                         FishInABarrel Web Application faces a range of security issues which makes
                         it vulnerable to a number of different attacks. Vulnerabilities found
                         included: cross-site scripting (both stored and reflected), cross-site
                         request forgery, information disclosure and lack of brute force
                         protection.</p>
-                <p>Our conclusion is that there are a number of things that FishInABarrel BV has to
+    <p>Our conclusion is that there are a number of things that FishInABarrel BV has to
                         fix before Sitting Duck should use their software. A number of the security
                         issues highlighted in this report have fairly simple solutions, but these
                         should nevertheless be fixed before use of the FishInABarrel Web App
                         continues.</p>
-                <p>We finally want to emphasize that security is a process – and this penetration
+    <p>We finally want to emphasize that security is a process – and this penetration
                         test is just a one-time snapshot. Security posture must be continuously
                         evaluated and improved. Regular audits and ongoing improvements are
                         essential in order to maintain control of your corporate information
@@ -351,9 +414,9 @@ Raw packets sent: 1681 (73.962KB) | Rcvd: 1681 (77.322KB)</pre>
                         our findings) will contribute meaningfully towards that end. Don't hesitate
                         to let us know if you have any further questions or need further
                         clarification of anything in this report.</p>
-        </section>
-        <appendix id="testteam">
-                <title>Testing team</title>
-                <generate_testteam/>
-        </appendix>
+  </section>
+  <appendix id="testteam">
+    <title>Testing team</title>
+    <generate_testteam />
+  </appendix>
 </pentest_report>

--- a/doc/examples/snippets
+++ b/doc/examples/snippets
@@ -1,0 +1,1 @@
+../../source/snippets

--- a/dtd/common.xsd
+++ b/dtd/common.xsd
@@ -644,7 +644,6 @@
   <xs:element name="org" type="xs:string" />
   <xs:element name="journal" type="xs:string" />
   <xs:element name="info" type="xs:string" />
-  <xs:element name="location" type="xs:string" />
   <xs:element name="pubdate" type="xs:string" />
   <xs:element name="accessed" type="xs:date" />
 

--- a/dtd/offerte.xsd
+++ b/dtd/offerte.xsd
@@ -60,6 +60,9 @@
         <xs:element minOccurs="0" ref="target_application"/>
         <xs:element minOccurs="0" ref="target_application_producer"/>
         <xs:element ref="breakdown" minOccurs="0"/>
+        <xs:element ref="participants" minOccurs="0"/>
+        <xs:element ref="location" minOccurs="0"/>
+        <xs:element ref="duration" minOccurs="0"/>
       </xs:all>
     </xs:complexType>
   </xs:element>
@@ -276,6 +279,10 @@
       <xs:element name="p_reportdue"/>
       <xs:element name="p_startdate"/>
       <xs:element name="p_enddate"/>
+      <xs:element name="p_draftdue"/>
+      <xs:element name="p_duration"/>
+      <xs:element name="p_location"/>
+      <xs:element name="p_participants"/>
       <xs:element name="signee_long"/>
       <xs:element name="signee_short"/>
       <xs:element name="signee_street"/>

--- a/dtd/pentestreport.xsd
+++ b/dtd/pentestreport.xsd
@@ -130,6 +130,7 @@
           <xs:element ref="generate_testteam"/>
           <xs:element name="p" type="block"/>
           <xs:element ref="pre"/>
+          <xs:element ref="code"/>
           <xs:element ref="table"/>
           <xs:element ref="ol"/>
           <xs:element ref="ul"/>
@@ -164,6 +165,7 @@
         <xs:element ref="title"/>
         <xs:choice minOccurs="0" maxOccurs="unbounded">
           <xs:element ref="pre"/>
+          <xs:element ref="code"/>
           <xs:element name="p" type="block"/>
           <xs:element ref="blockquote"/>
           <xs:element ref="section"/>
@@ -308,7 +310,7 @@
           <xs:element ref="description_summary"/>
         </xs:choice>
         <xs:element ref="technicaldescription"/>
-        <xs:element ref="impact"/>
+        <xs:element ref="impact" minOccurs="0"/>
         <xs:element ref="recommendation"/>
         <xs:choice minOccurs="0" maxOccurs="1">
           <xs:element ref="recommendation_summary"/>
@@ -324,6 +326,7 @@
       <xs:attribute ref="status" use="optional"/>
       <xs:attribute name="type" use="required"/>
       <xs:attribute name="number" use="required" type="xs:integer"/>
+      <xs:attribute name="prefix" use="optional" type="xs:string"/>
       <xs:attribute name="break" use="optional">
         <xs:simpleType>
           <xs:restriction base="xs:string">
@@ -366,6 +369,7 @@
         <xs:element name="img"/>
         <xs:element name="table"/>
         <xs:element ref="pre"/>
+        <xs:element ref="code"/>
         <xs:element ref="h2"/>
         <xs:element ref="h3"/>
         <xs:element ref="h4"/>


### PR DESCRIPTION
Resolve the examples' xi:includes via symlinks to source/, and fix the remaining schema violations:

- exampleinvoice: denomination usd
- examplereport: drop stale `<duration>` and unused `pieHeight`; add required `@number`
- examplequickscope: drop redundant `<days>`; give `<planning>` start/end

blocked by #162 