### PR TITLE
Add support for "Wont fix" retest status

### DIFF
--- a/doc/report/Report Writing - Procedure.md
+++ b/doc/report/Report Writing - Procedure.md
@@ -332,7 +332,7 @@ A finding consists of a `<finding>` element with the following attributes:
 There are two optional fields:
 
 - `status`, which can denote whether the finding is `new`, `unresolved`,
-  `not_retested` or `resolved`.
+  `not_retested`, `resolved`, or `wont_fix`.
 - `prefix`, to add a prefix to a finding identifier.
 
 Furthermore, the `<finding>` is made up of several sub-elements:

--- a/doc/report/Report Writing - Procedure.md
+++ b/doc/report/Report Writing - Procedure.md
@@ -332,7 +332,7 @@ A finding consists of a `<finding>` element with the following attributes:
 There are two optional fields:
 
 - `status`, which can denote whether the finding is `new`, `unresolved`,
-  `not_retested`, `resolved`, or `wont_fix`.
+  `not_retested`, `resolved`, or `accepted_risk`.
 - `prefix`, to add a prefix to a finding identifier.
 
 Furthermore, the `<finding>` is made up of several sub-elements:

--- a/dtd/pentestreport.xsd
+++ b/dtd/pentestreport.xsd
@@ -227,7 +227,7 @@
         <xs:enumeration value="resolved"/>
         <xs:enumeration value="unresolved"/>
         <xs:enumeration value="not_retested"/>
-        <xs:enumeration value="wont_fix"/>
+        <xs:enumeration value="accepted_risk"/>
         <xs:enumeration value="none"/>
       </xs:restriction>
     </xs:simpleType>

--- a/dtd/pentestreport.xsd
+++ b/dtd/pentestreport.xsd
@@ -227,6 +227,7 @@
         <xs:enumeration value="resolved"/>
         <xs:enumeration value="unresolved"/>
         <xs:enumeration value="not_retested"/>
+        <xs:enumeration value="wont_fix"/>
         <xs:enumeration value="none"/>
       </xs:restriction>
     </xs:simpleType>

--- a/xslt/auto.xslt
+++ b/xslt/auto.xslt
@@ -215,6 +215,14 @@
                                     <xsl:value-of select="$prettyStatus" />
                                 </fo:inline>
                             </xsl:when>
+                            <xsl:when test="@status = 'wont_fix'">
+                                <fo:inline>
+                                    <xsl:attribute name="color">
+                                        <xsl:value-of select="$color_wontfix"/>
+                                    </xsl:attribute>
+                                    <xsl:value-of select="$prettyStatus"/>
+                                </fo:inline>
+                            </xsl:when>
                             <xsl:otherwise>
                                 <fo:inline>
                                     <xsl:value-of select="@status" />
@@ -406,6 +414,14 @@
                                         <xsl:value-of select="$color_resolved"/>
                                     </xsl:attribute>
                                     <xsl:value-of select="$prettyStatus" />
+                                </fo:inline>
+                            </xsl:when>
+                            <xsl:when test="@status = 'wont_fix'">
+                                <fo:inline>
+                                    <xsl:attribute name="color">
+                                        <xsl:value-of select="$color_wontfix"/>
+                                    </xsl:attribute>
+                                    <xsl:value-of select="$prettyStatus"/>
                                 </fo:inline>
                             </xsl:when>
                             <xsl:otherwise>

--- a/xslt/auto.xslt
+++ b/xslt/auto.xslt
@@ -215,10 +215,10 @@
                                     <xsl:value-of select="$prettyStatus" />
                                 </fo:inline>
                             </xsl:when>
-                            <xsl:when test="@status = 'wont_fix'">
+                            <xsl:when test="@status = 'accepted_risk'">
                                 <fo:inline>
                                     <xsl:attribute name="color">
-                                        <xsl:value-of select="$color_wontfix"/>
+                                        <xsl:value-of select="$color_acceptedrisk"/>
                                     </xsl:attribute>
                                     <xsl:value-of select="$prettyStatus"/>
                                 </fo:inline>
@@ -416,10 +416,10 @@
                                     <xsl:value-of select="$prettyStatus" />
                                 </fo:inline>
                             </xsl:when>
-                            <xsl:when test="@status = 'wont_fix'">
+                            <xsl:when test="@status = 'accepted_risk'">
                                 <fo:inline>
                                     <xsl:attribute name="color">
-                                        <xsl:value-of select="$color_wontfix"/>
+                                        <xsl:value-of select="$color_acceptedrisk"/>
                                     </xsl:attribute>
                                     <xsl:value-of select="$prettyStatus"/>
                                 </fo:inline>

--- a/xslt/auto.xslt
+++ b/xslt/auto.xslt
@@ -2,8 +2,9 @@
 <xsl:stylesheet
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
-  exclude-result-prefixes="xs"
+  exclude-result-prefixes="xs my"
   xmlns:fo="http://www.w3.org/1999/XSL/Format"
+  xmlns:my="http://www.radical.sexy"
   version="2.0"
 >
 
@@ -146,10 +147,7 @@
     </xsl:template>
 
     <xsl:template name="findingsSummaryContent">
-        <fo:table-row
-      xsl:use-attribute-sets="TableFont"
-      keep-together.within-column="always"
-    >
+        <fo:table-row xsl:use-attribute-sets="TableFont" keep-together.within-column="always">
             <xsl:if test="position() mod 2 != 0">
                 <xsl:attribute name="background-color">#ededed</xsl:attribute>
             </xsl:if>
@@ -185,40 +183,36 @@
    
                 <!-- Status Section -->
                 <xsl:if test="@status and @status != 'none' and @status != ''">
-                  
+                    <xsl:variable name="prettyStatus">
+                        <xsl:sequence
+                            select="string-join(for $x in tokenize(@status, '_') return my:titleCase($x), ' ')"
+                        />
+                    </xsl:variable>
                     <fo:block>
-                        <fo:inline
-              xsl:use-attribute-sets="bold"
-            >Status: </fo:inline>
+                        <fo:inline xsl:use-attribute-sets="bold">Status: </fo:inline>
                         <xsl:choose>
-                            <xsl:when
-                test="@status = 'new' or @status = 'unresolved'"
-              >
+                            <xsl:when test="@status = 'new' or @status = 'unresolved'">
                                 <fo:inline>
                                     <xsl:attribute name="color">
                                         <xsl:value-of select="$color_new" />
                                     </xsl:attribute>
-                                    <xsl:value-of select="@status" />
+                                    <xsl:value-of select="$prettyStatus" />
                                 </fo:inline>
                             </xsl:when>
                             <xsl:when test="@status = 'not_retested'">
                                 <fo:inline>
                                     <xsl:attribute name="color">
-                                        <xsl:value-of
-                      select="$color_notretested"
-                    />
+                                        <xsl:value-of select="$color_notretested"/>
                                     </xsl:attribute>
-                                    <xsl:value-of select="@status" />
+                                    <xsl:value-of select="$prettyStatus" />
                                 </fo:inline>
                             </xsl:when>
                             <xsl:when test="@status = 'resolved'">
                                 <fo:inline>
                                     <xsl:attribute name="color">
-                                        <xsl:value-of
-                      select="$color_resolved"
-                    />
+                                        <xsl:value-of select="$color_resolved"/>
                                     </xsl:attribute>
-                                    <xsl:value-of select="@status" />
+                                    <xsl:value-of select="$prettyStatus" />
                                 </fo:inline>
                             </xsl:when>
                             <xsl:otherwise>
@@ -342,10 +336,7 @@
     </xsl:template>
 
     <xsl:template name="recommendationsSummaryContent">
-        <fo:table-row
-      xsl:use-attribute-sets="TableFont"
-      keep-together.within-column="always"
-    >
+        <fo:table-row xsl:use-attribute-sets="TableFont" keep-together.within-column="always">
             <xsl:if test="position() mod 2 != 0">
                 <xsl:attribute name="background-color">#ededed</xsl:attribute>
             </xsl:if>
@@ -371,55 +362,50 @@
                                     <xsl:value-of select="@threatLevel" />
                                 </xsl:when>
                             </xsl:choose>
-                        </fo:inline>                            
+                        </fo:inline>
                     </fo:block>
                 </xsl:if>
 
                 <!-- Type -->
                 <xsl:if test="@type">
                     <fo:block>
-                        <fo:inline
-              xsl:use-attribute-sets="bold"
-            >Type: </fo:inline>
+                        <fo:inline xsl:use-attribute-sets="bold">Type: </fo:inline>
                         <xsl:value-of select="@type" />
                     </fo:block>
                 </xsl:if>
 
-                <!-- Status -->
-                <xsl:if test="@status and @status != 'none'">
+                <!-- Status Section -->
+                <xsl:if test="@status and @status != 'none' and @status != ''">
+                    <xsl:variable name="prettyStatus">
+                        <xsl:sequence
+                            select="string-join(for $x in tokenize(@status, '_') return my:titleCase($x), ' ')"
+                        />
+                    </xsl:variable>
                     <fo:block>
-                        <fo:inline
-              xsl:use-attribute-sets="bold"
-            >Status: </fo:inline>
+                        <fo:inline xsl:use-attribute-sets="bold">Status: </fo:inline>
                         <xsl:choose>
-                            <xsl:when
-                test="@status = 'new' or @status = 'unresolved'"
-              >
+                            <xsl:when test="@status = 'new' or @status = 'unresolved'">
                                 <fo:inline>
                                     <xsl:attribute name="color">
                                         <xsl:value-of select="$color_new" />
                                     </xsl:attribute>
-                                    <xsl:value-of select="@status" />
+                                    <xsl:value-of select="$prettyStatus" />
                                 </fo:inline>
                             </xsl:when>
                             <xsl:when test="@status = 'not_retested'">
                                 <fo:inline>
                                     <xsl:attribute name="color">
-                                        <xsl:value-of
-                      select="$color_notretested"
-                    />
+                                        <xsl:value-of select="$color_notretested"/>
                                     </xsl:attribute>
-                                    <xsl:value-of select="@status" />
+                                    <xsl:value-of select="$prettyStatus" />
                                 </fo:inline>
                             </xsl:when>
                             <xsl:when test="@status = 'resolved'">
                                 <fo:inline>
                                     <xsl:attribute name="color">
-                                        <xsl:value-of
-                      select="$color_resolved"
-                    />
+                                        <xsl:value-of select="$color_resolved"/>
                                     </xsl:attribute>
-                                    <xsl:value-of select="@status" />
+                                    <xsl:value-of select="$prettyStatus" />
                                 </fo:inline>
                             </xsl:when>
                             <xsl:otherwise>
@@ -437,19 +423,14 @@
                         <xsl:for-each select="labels/label">
                             <fo:inline xsl:use-attribute-sets="label">
                                 <xsl:attribute name="background-color">
-                                    <xsl:value-of
-                    select="/pentest_report/meta/labels/label[@name = current()]/@color"
-                  />
+                                    <xsl:value-of select="/pentest_report/meta/labels/label[@name = current()]/@color"/>
                                 </xsl:attribute>
                                 <xsl:attribute name="color">
-                                    <xsl:value-of
-                    select="/pentest_report/meta/labels/label[@name = current()]/@text"
-                  />
+                                    <xsl:value-of select="/pentest_report/meta/labels/label[@name = current()]/@text"/>
                                 </xsl:attribute>
                                 <xsl:value-of select="." />
                             </fo:inline>
-                            <xsl:text
-              > </xsl:text> <!-- Add space between labels -->
+                            <xsl:text> </xsl:text> <!-- Add space between labels -->
                         </xsl:for-each>
                     </fo:block>
                 </xsl:if>

--- a/xslt/css.xslt
+++ b/xslt/css.xslt
@@ -602,6 +602,10 @@ there.
     color: <xsl:value-of select="$color_notretested"/>;
 }
 
+.status-wont_fix {
+    color: <xsl:value-of select="$color_wontfix"/>;
+}
+
 .status-resolved {
     color: <xsl:value-of select="$color_resolved"/>;
 }

--- a/xslt/css.xslt
+++ b/xslt/css.xslt
@@ -602,8 +602,8 @@ there.
     color: <xsl:value-of select="$color_notretested"/>;
 }
 
-.status-wont_fix {
-    color: <xsl:value-of select="$color_wontfix"/>;
+.status-accepted_risk {
+    color: <xsl:value-of select="$color_acceptedrisk"/>;
 }
 
 .status-resolved {

--- a/xslt/findings.xslt
+++ b/xslt/findings.xslt
@@ -32,7 +32,7 @@
                         </fo:block>
                     </fo:table-cell>
                     <xsl:if
-                        test="@status = 'new' or @status = 'resolved' or @status = 'unresolved' or @status = 'not_retested'">
+                        test="@status = 'new' or @status = 'resolved' or @status = 'unresolved' or @status = 'not_retested' or @status = 'wont_fix'">
                         <fo:table-cell xsl:use-attribute-sets="td">
                             <fo:block xsl:use-attribute-sets="finding-meta">
                                 <fo:inline xsl:use-attribute-sets="bold">Status: </fo:inline>
@@ -49,6 +49,11 @@
                                     </xsl:when>
                                     <xsl:when test="@status = 'resolved'">
                                         <fo:inline xsl:use-attribute-sets="status-resolved">
+                                            <xsl:value-of select="$prettyStatus"/>
+                                        </fo:inline>
+                                    </xsl:when>
+                                    <xsl:when test="@status = 'wont_fix'">
+                                        <fo:inline xsl:use-attribute-sets="status-wont_fix">
                                             <xsl:value-of select="$prettyStatus"/>
                                         </fo:inline>
                                     </xsl:when>
@@ -157,7 +162,7 @@
 
     <xsl:template match="update" name="update">
         <xsl:if
-            test="../@status = 'resolved' or ../@status = 'unresolved' or ../@status = 'not_retested'">
+            test="../@status = 'resolved' or ../@status = 'unresolved' or ../@status = 'not_retested' or ../@status = 'wont_fix'">
             <fo:block xsl:use-attribute-sets="title-findingsection">
                 <xsl:choose>
                 <xsl:when test="../@status = 'unresolved'">
@@ -172,6 +177,11 @@
                 </xsl:when>
                 <xsl:when test="../@status = 'resolved'">
                     <fo:inline xsl:use-attribute-sets="status-resolved">
+                        Update
+                    </fo:inline>
+                </xsl:when>
+                <xsl:when test="../@status = 'wont_fix'">
+                    <fo:inline xsl:use-attribute-sets="status-wont_fix">
                         Update
                     </fo:inline>
                 </xsl:when>

--- a/xslt/findings.xslt
+++ b/xslt/findings.xslt
@@ -175,7 +175,7 @@
                         Update
                     </fo:inline>
                 </xsl:when>
-            </xsl:choose>
+                </xsl:choose>
                 <xsl:if test="@date">
                     <xsl:text> </xsl:text>
                     <fo:inline xsl:use-attribute-sets="status-tag">

--- a/xslt/findings.xslt
+++ b/xslt/findings.xslt
@@ -32,7 +32,7 @@
                         </fo:block>
                     </fo:table-cell>
                     <xsl:if
-                        test="@status = 'new' or @status = 'resolved' or @status = 'unresolved' or @status = 'not_retested' or @status = 'wont_fix'">
+                        test="@status = 'new' or @status = 'resolved' or @status = 'unresolved' or @status = 'not_retested' or @status = 'accepted_risk'">
                         <fo:table-cell xsl:use-attribute-sets="td">
                             <fo:block xsl:use-attribute-sets="finding-meta">
                                 <fo:inline xsl:use-attribute-sets="bold">Status: </fo:inline>
@@ -52,8 +52,8 @@
                                             <xsl:value-of select="$prettyStatus"/>
                                         </fo:inline>
                                     </xsl:when>
-                                    <xsl:when test="@status = 'wont_fix'">
-                                        <fo:inline xsl:use-attribute-sets="status-wont_fix">
+                                    <xsl:when test="@status = 'accepted_risk'">
+                                        <fo:inline xsl:use-attribute-sets="status-accepted_risk">
                                             <xsl:value-of select="$prettyStatus"/>
                                         </fo:inline>
                                     </xsl:when>
@@ -162,7 +162,7 @@
 
     <xsl:template match="update" name="update">
         <xsl:if
-            test="../@status = 'resolved' or ../@status = 'unresolved' or ../@status = 'not_retested' or ../@status = 'wont_fix'">
+            test="../@status = 'resolved' or ../@status = 'unresolved' or ../@status = 'not_retested' or ../@status = 'accepted_risk'">
             <fo:block xsl:use-attribute-sets="title-findingsection">
                 <xsl:choose>
                 <xsl:when test="../@status = 'unresolved'">
@@ -180,8 +180,8 @@
                         Update
                     </fo:inline>
                 </xsl:when>
-                <xsl:when test="../@status = 'wont_fix'">
-                    <fo:inline xsl:use-attribute-sets="status-wont_fix">
+                <xsl:when test="../@status = 'accepted_risk'">
+                    <fo:inline xsl:use-attribute-sets="status-accepted_risk">
                         Update
                     </fo:inline>
                 </xsl:when>

--- a/xslt/functions_params_vars.xslt
+++ b/xslt/functions_params_vars.xslt
@@ -53,7 +53,7 @@
     <xsl:variable name="color_new">#CC4900</xsl:variable>
     <xsl:variable name="color_unresolved">#FF5C00</xsl:variable>
     <xsl:variable name="color_notretested">#FE9920</xsl:variable>
-    <xsl:variable name="color_wontfix">#333333</xsl:variable>
+    <xsl:variable name="color_acceptedrisk">#333333</xsl:variable>
     <xsl:variable name="color_resolved">#15B01A</xsl:variable>
 
     <!-- generic pie chart colors -->
@@ -321,8 +321,8 @@
             <xsl:when test="$label = 'not_retested'">
                 <xsl:value-of select="$color_notretested"/>
             </xsl:when>
-            <xsl:when test="$label = 'wont_fix'">
-                <xsl:value-of select="$color_wontfix"/>
+            <xsl:when test="$label = 'accepted_risk'">
+                <xsl:value-of select="$color_acceptedrisk"/>
             </xsl:when>
             <xsl:when test="$label = 'resolved'">
                 <xsl:value-of select="$color_resolved"/>

--- a/xslt/functions_params_vars.xslt
+++ b/xslt/functions_params_vars.xslt
@@ -53,6 +53,7 @@
     <xsl:variable name="color_new">#CC4900</xsl:variable>
     <xsl:variable name="color_unresolved">#FF5C00</xsl:variable>
     <xsl:variable name="color_notretested">#FE9920</xsl:variable>
+    <xsl:variable name="color_wontfix">#333333</xsl:variable>
     <xsl:variable name="color_resolved">#15B01A</xsl:variable>
 
     <!-- generic pie chart colors -->
@@ -319,6 +320,9 @@
             </xsl:when>
             <xsl:when test="$label = 'not_retested'">
                 <xsl:value-of select="$color_notretested"/>
+            </xsl:when>
+            <xsl:when test="$label = 'wont_fix'">
+                <xsl:value-of select="$color_wontfix"/>
             </xsl:when>
             <xsl:when test="$label = 'resolved'">
                 <xsl:value-of select="$color_resolved"/>

--- a/xslt/generate_html_report.xsl
+++ b/xslt/generate_html_report.xsl
@@ -626,6 +626,11 @@
                                     <xsl:value-of select="$prettyStatus"/>
                                 </span>
                             </xsl:when>
+                            <xsl:when test="@status = 'wont_fix'">
+                                <span class="status-wont_fix">
+                                    <xsl:value-of select="$prettyStatus"/>
+                                </span>
+                            </xsl:when>
                         </xsl:choose>
                     </div>
                 </xsl:if>

--- a/xslt/generate_html_report.xsl
+++ b/xslt/generate_html_report.xsl
@@ -626,8 +626,8 @@
                                     <xsl:value-of select="$prettyStatus"/>
                                 </span>
                             </xsl:when>
-                            <xsl:when test="@status = 'wont_fix'">
-                                <span class="status-wont_fix">
+                            <xsl:when test="@status = 'accepted_risk'">
+                                <span class="status-accepted_risk">
                                     <xsl:value-of select="$prettyStatus"/>
                                 </span>
                             </xsl:when>

--- a/xslt/styles_rep.xslt
+++ b/xslt/styles_rep.xslt
@@ -16,8 +16,8 @@
     <xsl:attribute-set name="status-not_retested">
         <xsl:attribute name="color"><xsl:value-of select="$color_notretested"/></xsl:attribute>
     </xsl:attribute-set>
-    <xsl:attribute-set name="status-wont_fix">
-        <xsl:attribute name="color"><xsl:value-of select="$color_wontfix"/></xsl:attribute>
+    <xsl:attribute-set name="status-accepted_risk">
+        <xsl:attribute name="color"><xsl:value-of select="$color_acceptedrisk"/></xsl:attribute>
     </xsl:attribute-set>
 
     <!-- Status tags -->

--- a/xslt/styles_rep.xslt
+++ b/xslt/styles_rep.xslt
@@ -16,7 +16,10 @@
     <xsl:attribute-set name="status-not_retested">
         <xsl:attribute name="color"><xsl:value-of select="$color_notretested"/></xsl:attribute>
     </xsl:attribute-set>
-    
+    <xsl:attribute-set name="status-wont_fix">
+        <xsl:attribute name="color"><xsl:value-of select="$color_wontfix"/></xsl:attribute>
+    </xsl:attribute-set>
+
     <!-- Status tags -->
     <xsl:attribute-set name="status-tag">
         <xsl:attribute name="background-color"><xsl:value-of select="$c_support_light"/></xsl:attribute>


### PR DESCRIPTION
It doesn't really fit into any of the other categories.

While I was doing this I also added support for using the same "pretty" status names that are used in findings in the summary tables too.

I also cleaned up some of the code a bit as it was hard to read in places – it could do with reformatting properly!